### PR TITLE
Link command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto-detect text vs. binary files and ensure newlines are always LF for
+# text files on check-out and check-in.
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ $ npm install -g symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (-v|--version|version)
-symbol-bootstrap/0.1.0 linux-x64 node-v14.8.0
+symbol-bootstrap/0.1.0 linux-x64 node-v12.18.4
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND

--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ transactions:
 
 ````yaml
 nodes:
-  - roles: 'Peer,Voting'
-    voting: true
+  - voting: true
 ````
 
 In order to activate the voting node, you will need to announce a `VotingKeyLinkTransaction` signed using the node's signing private, and the voting public key (suffixed with `00000000000000000000000000000000`).
@@ -166,6 +165,15 @@ In order to activate the voting node, you will need to announce a `VotingKeyLink
 The node signing and voting keys are stored in the `./target/config/generated-addresses/addresses.yml`. Keep this file private!
 
 **Note:** Full network `-p bootstrap` nodes are fully configured voting nodes. `VotingKeyLinkTransaction` are added to the nemesis block automatically. 
+
+
+##### Disable voting mode in all bootstrap nodes:
+
+````yaml
+nodes:
+  - voting: false
+  - voting: false
+````
 
 ## Target:
 
@@ -182,7 +190,7 @@ The folder where the generated config, docker files and data are stored. The fol
 
 # Requirements
 
--   NPM 10+
+-   Node 10+
 -   Docker
 -   Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ General users should install this tool like any other node module.
 * [`symbol-bootstrap compose`](docs/compose.md) - It generates the `docker-compose.yml` file from the configured network.
 * [`symbol-bootstrap config`](docs/config.md) - Command used to set up the configuration files and the nemesis block for the current network
 * [`symbol-bootstrap help`](docs/help.md) - display help for symbol-bootstrap
+* [`symbol-bootstrap link`](docs/link.md) - It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
 * [`symbol-bootstrap run`](docs/run.md) - It boots the network via docker using the generated `docker-compose.yml` file and configuration. The config and compose methods/commands need to be called before this method. This is just a wrapper for the `docker-compose up` bash call.
 * [`symbol-bootstrap start`](docs/start.md) - Single command that aggregates config, compose and run in one line!
 * [`symbol-bootstrap stop`](docs/stop.md) - It stops the docker-compose network if running (symbol-bootstrap started with --detached). This is just a wrapper for the `docker-compose down` bash call.

--- a/README.md
+++ b/README.md
@@ -160,11 +160,15 @@ nodes:
   - voting: true
 ````
 
-In order to activate the voting node, you will need to announce a `VotingKeyLinkTransaction` signed using the node's signing private, and the voting public key (suffixed with `00000000000000000000000000000000`).
+In order to finalize the peer or voting nodes registration to an existing network like Testnet, be sure your nodes' signing addresses have enough funds. For test environments, you can use the network's faucet.
 
-The node signing and voting keys are stored in the `./target/config/generated-addresses/addresses.yml`. Keep this file private!
+Then run:
 
-**Note:** Full network `-p bootstrap` nodes are fully configured voting nodes. `VotingKeyLinkTransaction` are added to the nemesis block automatically. 
+````
+symbol-bootstrap link
+````
+
+**Note:** Full network `-p bootstrap` nodes are fully configured voting and peer nodes. `VotingKeyLinkTransaction` and `VrfKeyLinkTransaction` are added to the nemesis block automatically. 
 
 
 ##### Disable voting mode in all bootstrap nodes:
@@ -363,7 +367,7 @@ General users should install this tool like any other node module.
 * [`symbol-bootstrap compose`](docs/compose.md) - It generates the `docker-compose.yml` file from the configured network.
 * [`symbol-bootstrap config`](docs/config.md) - Command used to set up the configuration files and the nemesis block for the current network
 * [`symbol-bootstrap help`](docs/help.md) - display help for symbol-bootstrap
-* [`symbol-bootstrap link`](docs/link.md) - It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
+* [`symbol-bootstrap link`](docs/link.md) - It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
 * [`symbol-bootstrap run`](docs/run.md) - It boots the network via docker using the generated `docker-compose.yml` file and configuration. The config and compose methods/commands need to be called before this method. This is just a wrapper for the `docker-compose up` bash call.
 * [`symbol-bootstrap start`](docs/start.md) - Single command that aggregates config, compose and run in one line!
 * [`symbol-bootstrap stop`](docs/stop.md) - It stops the docker-compose network if running (symbol-bootstrap started with --detached). This is just a wrapper for the `docker-compose down` bash call.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ nodes:
     voting: true
 ````
 
-In order to activate the voting node, you will need to announce a `VotingKeyLinkTransaction` singed using the node's signing private, and the voting public key (suffixed with `00000000000000000000000000000000`).
+In order to activate the voting node, you will need to announce a `VotingKeyLinkTransaction` signed using the node's signing private, and the voting public key (suffixed with `00000000000000000000000000000000`).
 
 The node signing and voting keys are stored in the `./target/config/generated-addresses/addresses.yml`. Keep this file private!
 

--- a/cmds/link-testnet-external-node.sh
+++ b/cmds/link-testnet-external-node.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+symbol-bootstrap link -t target/testnet -u http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/

--- a/cmds/link-testnet-external-node.sh
+++ b/cmds/link-testnet-external-node.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-symbol-bootstrap link -t target/testnet -u http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/
+symbol-bootstrap link -t target/testnet -u http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/ $1

--- a/cmds/link-testnet.sh
+++ b/cmds/link-testnet.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-symbol-bootstrap link -t target/testnet
-http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/
+symbol-bootstrap link -t target/testnet $1

--- a/cmds/link-testnet.sh
+++ b/cmds/link-testnet.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+symbol-bootstrap link -t target/testnet
+http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/

--- a/cmds/start-bootstrap-custom.sh
+++ b/cmds/start-bootstrap-custom.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+symbol-bootstrap start -u current -p bootstrap -c test/custom_preset.yml -t target/bootstrap-custom $1

--- a/cmds/start-testnet-voting.sh
+++ b/cmds/start-testnet-voting.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-symbol-bootstrap start -p testnet -a dual -t target/testnet-voting -c test/voting_preset.yml  $1
+symbol-bootstrap start -p testnet -a dual -t target/testnet -c test/voting_preset.yml  $1

--- a/cmds/start-testnet-voting.sh
+++ b/cmds/start-testnet-voting.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-symbol-bootstrap start -p testnet -a api -t target/testnet-voting -c test/voting_preset.yml  $1
+symbol-bootstrap start -p testnet -a dual -t target/testnet-voting -c test/voting_preset.yml  $1

--- a/cmds/start-testnet-voting.sh
+++ b/cmds/start-testnet-voting.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+symbol-bootstrap start -p testnet -a api -t target/testnet-voting -c test/voting_preset.yml  $1

--- a/cmds/start-testnet.sh
+++ b/cmds/start-testnet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-symbol-bootstrap start -p testnet -a dual -u current -t target/testnet-dual $1
+symbol-bootstrap start -p testnet -a dual -u current -t target/testnet $1

--- a/config/docker/dockerfiles/catapult/userconfig/startBroker.sh
+++ b/config/docker/dockerfiles/catapult/userconfig/startBroker.sh
@@ -2,7 +2,6 @@
 
 name=$1
 echo "RUNNING running startBroker.sh $name"
-hostname
 source /userconfig/prepare.sh $name
 
 ulimit -c unlimited

--- a/config/docker/dockerfiles/catapult/userconfig/startBroker.sh
+++ b/config/docker/dockerfiles/catapult/userconfig/startBroker.sh
@@ -2,6 +2,7 @@
 
 name=$1
 echo "RUNNING running startBroker.sh $name"
+hostname
 source /userconfig/prepare.sh $name
 
 ulimit -c unlimited

--- a/config/docker/dockerfiles/catapult/userconfig/startServer.sh
+++ b/config/docker/dockerfiles/catapult/userconfig/startServer.sh
@@ -2,7 +2,6 @@
 
 name=$1
 echo "RUNNING startServer.sh $name"
-hostname
 source /userconfig/prepare.sh $name
 id -a
 

--- a/config/docker/dockerfiles/catapult/userconfig/startServer.sh
+++ b/config/docker/dockerfiles/catapult/userconfig/startServer.sh
@@ -2,6 +2,7 @@
 
 name=$1
 echo "RUNNING startServer.sh $name"
+hostname
 source /userconfig/prepare.sh $name
 id -a
 

--- a/config/node/resources/config-finalization.properties.mustache
+++ b/config/node/resources/config-finalization.properties.mustache
@@ -11,4 +11,4 @@ messageSynchronizationMaxResponseSize = 20MB
 
 maxHashesPerPoint = 256
 prevoteBlocksMultiple = 4
-votingKeyDilution = 128
+votingKeyDilution = {{{votingKeyDilution}}}

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap clean
 ```
 
-_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/clean.ts)_
+_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/clean.ts)_

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -25,4 +25,4 @@ EXAMPLE
   $ symbol-bootstrap compose
 ```
 
-_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/compose.ts)_
+_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/compose.ts)_

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,4 +34,4 @@ EXAMPLE
   $ symbol-bootstrap config -p bootstrap
 ```
 
-_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/config.ts)_

--- a/docs/link.md
+++ b/docs/link.md
@@ -1,0 +1,26 @@
+`symbol-bootstrap link`
+=======================
+
+It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
+
+* [`symbol-bootstrap link`](#symbol-bootstrap-link)
+
+## `symbol-bootstrap link`
+
+It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
+
+```
+USAGE
+  $ symbol-bootstrap link
+
+OPTIONS
+  -h, --help           It shows the help of this command.
+  -t, --target=target  [default: target] the target folder
+  -u, --url=url        [default: http://localhost:3000] the network url
+  --maxFee=maxFee      [default: 100000] the max fee used when announcing
+
+EXAMPLE
+  $ symbol-bootstrap link
+```
+
+_See code: [src/commands/link.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/link.ts)_

--- a/docs/link.md
+++ b/docs/link.md
@@ -1,13 +1,13 @@
 `symbol-bootstrap link`
 =======================
 
-It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
+It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
 
 * [`symbol-bootstrap link`](#symbol-bootstrap-link)
 
 ## `symbol-bootstrap link`
 
-It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.
+It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
 
 ```
 USAGE
@@ -18,6 +18,7 @@ OPTIONS
   -t, --target=target  [default: target] the target folder
   -u, --url=url        [default: http://localhost:3000] the network url
   --maxFee=maxFee      [default: 100000] the max fee used when announcing
+  --unlink             Perform "Unlink" transactions unlinking the voting and VRF keys from the node signer account
 
 EXAMPLE
   $ symbol-bootstrap link

--- a/docs/run.md
+++ b/docs/run.md
@@ -21,7 +21,7 @@ OPTIONS
 
   -h, --help             It shows the help of this command.
 
-  -s, --service=service  If you are starting a particular service, example rest-gateway, db, node-peer-0
+  -s, --service=service  To start a particular docker compose service by name, example rest-gateway, db, node-peer-0
 
   -t, --target=target    [default: target] the target folder
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -31,4 +31,4 @@ EXAMPLE
   $ symbol-bootstrap run
 ```
 
-_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/run.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -46,4 +46,4 @@ EXAMPLES
   $ symbol-bootstrap start -p testnet -a dual
 ```
 
-_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/start.ts)_
+_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/start.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -29,8 +29,8 @@ OPTIONS
 
   -r, --reset                             It resets the configuration generating a new one
 
-  -s, --service=service                   If you are starting a particular service, example rest-gateway, db,
-                                          node-peer-0
+  -s, --service=service                   To start a particular docker compose service by name, example rest-gateway,
+                                          db, node-peer-0
 
   -t, --target=target                     [default: target] the target folder
 

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap stop
 ```
 
-_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.0/src/commands/stop.ts)_
+_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/stop.ts)_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-bootstrap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "symbol-bootstrap",
     "description": "Symbol tool that allows you creating, configuring and running Symbol's networks",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "author": "Fernando Boucquez <fboucquez@gmail.com>",
     "bin": {
         "symbol-bootstrap": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "eslint-plugin-prettier": "^3.1.3",
         "globby": "^10.0.2",
         "mocha": "^5.2.0",
+        "rxjs": "^6.5.3",
         "mocha-lcov-reporter": "^1.3.0",
         "nyc": "^14.1.1",
         "prettier": "^2.0.5",

--- a/presets/bootstrap/network.yml
+++ b/presets/bootstrap/network.yml
@@ -34,48 +34,48 @@ databases:
       openPort: true
 nodes:
     - harvesting: true
+      voting: true
+      api: false
       type: peer-node
       syncsource: true
       filespooling: false
       partialtransaction: false
-      voting: true
       name: 'peer-node-0'
       friendlyName: 'peer-node-0'
       host: 'peer-node-0'
       sinkType: 'Sync'
-      roles: 'Peer,Voting'
       enableSingleThreadPool: true
       addressextraction: false
       mongo: false
       zeromq: false
-    - harvesting: false
+    - harvesting: true
+      voting: true
+      api: false
       type: peer-node
       syncsource: true
       filespooling: false
       partialtransaction: false
-      voting: true
       friendlyName: 'peer-node-1'
       name: 'peer-node-1'
       host: 'peer-node-1'
       sinkType: 'Sync'
-      roles: 'Peer,Voting'
       enableSingleThreadPool: true
       addressextraction: false
       mongo: false
       zeromq: false
     - harvesting: false
+      voting: false
+      api: true
       type: api-node
       syncsource: false
       filespooling: true
       partialtransaction: true
-      voting: true
       friendlyName: 'api-node-0'
       name: 'api-node-0'
       host: 'api-node-0'
       brokerHost: 'api-node-broker-0'
       openBrokerPort: true
       sinkType: 'Async'
-      roles: 'Api,Voting'
       enableSingleThreadPool: false
       addressextraction: true
       mongo: true

--- a/presets/light/network.yml
+++ b/presets/light/network.yml
@@ -34,17 +34,17 @@ databases:
       openPort: true
 nodes:
     - harvesting: true
+      voting: true
+      api: true
       type: peer-node
       syncsource: true
       filespooling: true
       partialtransaction: true
-      voting: true
       name: 'api-node'
       databaseHost: 'db'
       host: ''
       openPort: true
       sinkType: 'Async'
-      roles: 'Api,Peer,Voting'
       enableSingleThreadPool: false
       brokerHost: 'api-broker'
       openBrokerPort: true

--- a/presets/light/network.yml
+++ b/presets/light/network.yml
@@ -35,7 +35,6 @@ databases:
 nodes:
     - harvesting: true
       type: peer-node
-      enableDispatcherInputAuditing: false
       syncsource: true
       filespooling: true
       partialtransaction: true

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -43,7 +43,6 @@ maxBondedTransactionLifetime: 48h
 maxTransactionsPerBlock: 6000
 stepDuration: 4m
 minNamespaceDuration: 1m
-enableDispatcherInputAuditing: true
 trustedHosts: 127.0.0.1, 172.20.0.25
 localNetworks: 127.0.0.1, 172.20.0.25
 lockedFundsPerAggregate: 10000000

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -95,6 +95,7 @@ blockElementTraceInterval: 1
 transactionDisruptorSize: 16384
 transactionElementTraceInterval: 10
 enableDispatcherAbortWhenFull: false
+enableDispatcherInputAuditing: false
 maxCacheDatabaseWriteBatchSize: 5MB
 maxTrackedNodes: 5'000
 

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -121,3 +121,9 @@ maxReadRateMonitoringTotalSize: 100MB
 #Rest
 throttlingBurst: 35
 throttlingRate: 20
+
+
+#voting
+votingKeyDilution: 128
+votingKeyStartEpoch: 1
+votingKeyEndEpoch: 26280

--- a/presets/testnet/assembly-api.yml
+++ b/presets/testnet/assembly-api.yml
@@ -3,6 +3,8 @@ databases:
       openPort: true
 nodes:
     - harvesting: false
+      voting: false
+      api: true
       type: api-node
       syncsource: false
       filespooling: true
@@ -12,7 +14,6 @@ nodes:
       brokerHost: 'api-node-broker'
       openBrokerPort: true
       sinkType: 'Async'
-      roles: 'Api'
       enableSingleThreadPool: false
       addressextraction: true
       mongo: true
@@ -20,7 +21,6 @@ nodes:
       databaseHost: 'db'
       enableAutoSyncCleanup: false
       openPort: true
-      voting: false
 gateways:
     - apiNodeConfigPath: '/usr/local/share/symbol/api-node-config'
       name: 'rest-gateway'

--- a/presets/testnet/assembly-dual.yml
+++ b/presets/testnet/assembly-dual.yml
@@ -3,6 +3,8 @@ databases:
       openPort: false
 nodes:
     - harvesting: true
+      voting: false
+      api: true
       type: peer-node
       syncsource: true
       filespooling: true
@@ -12,7 +14,6 @@ nodes:
       host: ''
       openPort: true
       sinkType: 'Async'
-      roles: 'Api,Peer'
       enableSingleThreadPool: false
       brokerHost: 'api-broker'
       openBrokerPort: true
@@ -20,7 +21,6 @@ nodes:
       enableAutoSyncCleanup: false
       mongo: true
       zeromq: true
-      voting: false
 gateways:
     - apiNodeConfigPath: '/usr/local/share/symbol/api-node-config'
       name: 'rest-gateway'

--- a/presets/testnet/assembly-dual.yml
+++ b/presets/testnet/assembly-dual.yml
@@ -4,7 +4,6 @@ databases:
 nodes:
     - harvesting: true
       type: peer-node
-      enableDispatcherInputAuditing: false
       syncsource: true
       filespooling: true
       partialtransaction: true

--- a/presets/testnet/assembly-peer.yml
+++ b/presets/testnet/assembly-peer.yml
@@ -1,6 +1,8 @@
 localNetworks: 127.0.0.1
 nodes:
     - harvesting: true
+      voting: false
+      api: false
       type: peer-node
       syncsource: true
       filespooling: false
@@ -9,9 +11,7 @@ nodes:
       openPort: true
       host: 'peer-node'
       sinkType: 'Sync'
-      roles: 'Peer'
       enableSingleThreadPool: true
       addressextraction: false
       mongo: false
       zeromq: false
-      voting: false

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -21,6 +21,7 @@ nemesisSignerPublicKey: 78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE
 harvestNetworkFeeSinkAddress: TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
 mosaicRentalFeeSinkAddress: TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
 namespaceRentalFeeSinkAddress: TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
+faucetUrl: 'http://faucet-0.10.0.x-01.symboldev.network'
 trustedHosts:
 inflation:
     starting-at-height-2: 95998521

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -15,7 +15,6 @@ votingSetGrouping: 720
 maxSecretLockDuration: 365d
 maxNamespaceDuration: 1825d
 namespaceGracePeriodDuration: 1d
-enableDispatcherInputAuditing: false
 blockGenerationTargetTime: 30s
 nemesisGenerationHashSeed: 6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD
 nemesisSignerPublicKey: 78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,9 +1,9 @@
 import { Command, flags } from '@oclif/command';
-import { BootstrapService, BootstrapUtils } from '../service';
+import { BootstrapService, BootstrapUtils, ComposeService } from '../service';
 import { LinkService } from '../service/LinkService';
 
 export default class Link extends Command {
-    static description = `It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.`;
+    static description = `It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.`;
 
     static examples = [`$ symbol-bootstrap link`];
 
@@ -18,6 +18,10 @@ export default class Link extends Command {
             char: 'u',
             description: 'the network url',
             default: LinkService.defaultParams.url,
+        }),
+        unlink: flags.boolean({
+            description: 'Perform "Unlink" transactions unlinking the voting and VRF keys from the node signer account',
+            default: ComposeService.defaultParams.reset,
         }),
         maxFee: flags.integer({
             description: 'the max fee used when announcing',

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,0 +1,33 @@
+import { Command, flags } from '@oclif/command';
+import { BootstrapService, BootstrapUtils } from '../service';
+import { LinkService } from '../service/LinkService';
+
+export default class Link extends Command {
+    static description = `It calls a running server announcing all the node transactions like VRF and Voting. This command is useful to link the nodes keys to an existing running network like testnet.`;
+
+    static examples = [`$ symbol-bootstrap link`];
+
+    static flags = {
+        help: flags.help({ char: 'h', description: 'It shows the help of this command.' }),
+        target: flags.string({
+            char: 't',
+            description: 'the target folder',
+            default: LinkService.defaultParams.target,
+        }),
+        url: flags.string({
+            char: 'u',
+            description: 'the network url',
+            default: LinkService.defaultParams.url,
+        }),
+        maxFee: flags.integer({
+            description: 'the max fee used when announcing',
+            default: LinkService.defaultParams.maxFee,
+        }),
+    };
+
+    public async run(): Promise<void> {
+        const { flags } = this.parse(Link);
+        BootstrapUtils.showBanner();
+        return new BootstrapService(this.config.root).link(flags);
+    }
+}

--- a/src/model/Addresses.ts
+++ b/src/model/Addresses.ts
@@ -15,7 +15,8 @@ export interface NodeAccount {
     ssl: CertificatePair;
     type: NodeType;
     vrf: ConfigAccount;
-    voting: ConfigAccount;
+    voting?: ConfigAccount;
+    roles: string;
     name: string;
     friendlyName: string;
 }

--- a/src/model/Addresses.ts
+++ b/src/model/Addresses.ts
@@ -11,10 +11,13 @@ export interface ConfigAccount extends CertificatePair {
 }
 
 export interface NodeAccount {
-    signing: ConfigAccount;
     ssl: CertificatePair;
     type: NodeType;
-    vrf: ConfigAccount;
+    //Signing key is produced if node is peer or voting
+    signing?: ConfigAccount;
+    // VRF key is produced if node is peer
+    vrf?: ConfigAccount;
+    // Voting key is produced if node is voting
     voting?: ConfigAccount;
     roles: string;
     name: string;

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -51,6 +51,7 @@ export interface GatewayPreset {
 }
 
 export interface ConfigPreset {
+    faucetUrl?: string;
     nemesis?: NemesisPreset;
     nemesisSeedFolder?: string; // Optional seed folder if user provides an external seed/00000 folder.
     assemblies?: string;

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -71,4 +71,7 @@ export interface ConfigPreset {
     symbolServerToolsImage: string;
     symbolServerImage: string;
     symbolRestImage: string;
+    votingKeyDilution: number;
+    votingKeyStartEpoch: number;
+    votingKeyEndEpoch: number;
 }

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -31,6 +31,9 @@ export interface NodePreset {
     // At least these properties.
     databaseHost: string;
     openBrokerPort: boolean;
+    harvesting: boolean;
+    api: boolean;
+    voting: boolean;
     host?: string;
     name: string;
     type: NodeType;

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -31,6 +31,7 @@ export interface NodePreset {
     // At least these properties.
     databaseHost: string;
     openBrokerPort: boolean;
+    host?: string;
     name: string;
     type: NodeType;
     roles: string;

--- a/src/model/DockerCompose.ts
+++ b/src/model/DockerCompose.ts
@@ -9,6 +9,7 @@ export interface DockerComposeService {
     image?: string;
     restart?: string;
     user?: string;
+    hostname?: string;
     command: string;
     stop_signal?: string;
     volumes?: string[];
@@ -16,7 +17,8 @@ export interface DockerComposeService {
     depends_on?: string[];
     networks?: {
         default: {
-            ipv4_address: string;
+            ipv4_address?: string;
+            aliases?: string[];
         };
     };
 }

--- a/src/service/BootstrapService.ts
+++ b/src/service/BootstrapService.ts
@@ -2,7 +2,8 @@ import { ConfigParams, ConfigResult, ConfigService } from './ConfigService';
 import { ComposeParams, ComposeService } from './ComposeService';
 import { RunParams, RunService } from './RunService';
 import { BootstrapUtils } from './BootstrapUtils';
-import { ConfigPreset } from '../model';
+import { Addresses, ConfigPreset } from '../model';
+import { LinkParams, LinkService } from './LinkService';
 
 export type StartParams = ConfigParams & ComposeParams & RunParams;
 
@@ -31,6 +32,24 @@ export class BootstrapService {
      */
     public async compose(config: ComposeParams = ComposeService.defaultParams, passedPresetData?: ConfigPreset): Promise<void> {
         await new ComposeService(this.root, config).run(passedPresetData);
+    }
+
+    /**
+     * It calls a running server announcing all the node transactions like VRF and Voting.
+     *
+     * This command is useful to link the nodes keys to an existing running network like testnet.
+     *
+     * @param config the params passed
+     * @param passedPresetData  the created preset if you know if, otherwise will load the latest one resolved from the target folder.
+     * @param passedAddresses  the created addresses if you know if, otherwise will load the latest one resolved from the target folder.
+     */
+
+    public async link(
+        config: LinkParams = LinkService.defaultParams,
+        passedPresetData?: ConfigPreset | undefined,
+        passedAddresses?: Addresses | undefined,
+    ): Promise<void> {
+        await new LinkService(config).run(passedPresetData, passedAddresses);
     }
 
     /**

--- a/src/service/BootstrapService.ts
+++ b/src/service/BootstrapService.ts
@@ -28,7 +28,7 @@ export class BootstrapService {
      * The config method/command needs to be called before this method
      *
      * @param config the params of the compose command.
-     * @param passedPresetData the created preset if you know if, otherwise will load the latest one resolved from the target folder.
+     * @param passedPresetData the created preset if you know it, otherwise will load the latest one resolved from the target folder.
      */
     public async compose(config: ComposeParams = ComposeService.defaultParams, passedPresetData?: ConfigPreset): Promise<void> {
         await new ComposeService(this.root, config).run(passedPresetData);
@@ -40,8 +40,8 @@ export class BootstrapService {
      * This command is useful to link the nodes keys to an existing running network like testnet.
      *
      * @param config the params passed
-     * @param passedPresetData  the created preset if you know if, otherwise will load the latest one resolved from the target folder.
-     * @param passedAddresses  the created addresses if you know if, otherwise will load the latest one resolved from the target folder.
+     * @param passedPresetData  the created preset if you know it, otherwise will load the latest one resolved from the target folder.
+     * @param passedAddresses  the created addresses if you know it, otherwise will load the latest one resolved from the target folder.
      */
 
     public async link(

--- a/src/service/BootstrapService.ts
+++ b/src/service/BootstrapService.ts
@@ -4,6 +4,7 @@ import { RunParams, RunService } from './RunService';
 import { BootstrapUtils } from './BootstrapUtils';
 import { Addresses, ConfigPreset } from '../model';
 import { LinkParams, LinkService } from './LinkService';
+import { DockerCompose } from '../model/DockerCompose';
 
 export type StartParams = ConfigParams & ComposeParams & RunParams;
 
@@ -30,8 +31,8 @@ export class BootstrapService {
      * @param config the params of the compose command.
      * @param passedPresetData the created preset if you know it, otherwise will load the latest one resolved from the target folder.
      */
-    public async compose(config: ComposeParams = ComposeService.defaultParams, passedPresetData?: ConfigPreset): Promise<void> {
-        await new ComposeService(this.root, config).run(passedPresetData);
+    public compose(config: ComposeParams = ComposeService.defaultParams, passedPresetData?: ConfigPreset): Promise<DockerCompose> {
+        return new ComposeService(this.root, config).run(passedPresetData);
     }
 
     /**

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -83,16 +83,26 @@ export class BootstrapUtils {
         }
     }
 
-    public static async runImageUsingExec(
-        image: string,
-        userId: string | undefined,
-        cmds: string[],
-        binds: string[],
-    ): Promise<{ stdout: string; stderr: string }> {
+    public static async runImageUsingExec({
+        image,
+        userId,
+        workdir,
+        cmds,
+        binds,
+    }: {
+        image: string;
+        userId?: string | undefined;
+        workdir?: string | undefined;
+        cmds: string[];
+        binds: string[];
+    }): Promise<{ stdout: string; stderr: string }> {
         const volumes = binds.map((b) => `-v ${b}`).join(' ');
         const userParam = userId ? `-u ${userId}` : '';
+        const workdirParam = workdir ? `--workdir=${workdir}` : '';
         const environmentParam = '--env LD_LIBRARY_PATH=/usr/catapult/lib:/usr/catapult/deps';
-        const runCommand = `docker run --rm ${userParam} ${environmentParam} ${volumes} ${image} ${cmds.map((a) => `"${a}"`).join(' ')}`;
+        const runCommand = `docker run --rm ${userParam} ${workdirParam} ${environmentParam} ${volumes} ${image} ${cmds
+            .map((a) => `"${a}"`)
+            .join(' ')}`;
         logger.info(`Running image using Exec: ${image} ${cmds.join(' ')}`);
         const { stdout, stderr } = await exec(runCommand);
         return { stdout, stderr };
@@ -159,7 +169,7 @@ export class BootstrapUtils {
     }
 
     public static createVotingKey(votingPublicKey: string): string {
-        return votingPublicKey + '00000000000000000000000000000000';
+        return votingPublicKey.padEnd(96, '0');
     }
 
     public static poll(promiseFunction: () => Promise<boolean>, totalPollingTime: number, pollIntervalMs: number): Promise<boolean> {

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -158,6 +158,10 @@ export class BootstrapUtils {
         });
     }
 
+    public static createVotingKey(votingPublicKey: string): string {
+        return votingPublicKey + '00000000000000000000000000000000';
+    }
+
     public static poll(promiseFunction: () => Promise<boolean>, totalPollingTime: number, pollIntervalMs: number): Promise<boolean> {
         const startTime = new Date().getMilliseconds();
         return promiseFunction().then(async (result) => {

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -47,10 +47,16 @@ export class CertificateService {
 
         const command = this.createCertCommands('/data');
         await BootstrapUtils.writeTextFile(target + '/createCertificate.sh', command);
-        const cmd = ['bash', '-c', 'cd /data && bash createCertificate.sh'];
+        const cmd = ['bash', 'createCertificate.sh'];
         const binds = [`${resolve(target)}:/data:rw`];
         const userId = await BootstrapUtils.resolveDockerUserFromParam(this.params.user);
-        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec(symbolServerToolsImage, userId, cmd, binds);
+        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec({
+            image: symbolServerToolsImage,
+            userId: userId,
+            workdir: '/data',
+            cmds: cmd,
+            binds: binds,
+        });
         const privateKey = this.getKey(stdout, 'priv:', 'pub:');
         const publicKey = this.getKey(stdout, 'pub:', 'Certificate:');
 

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -70,12 +70,12 @@ export class ComposeService {
         });
 
         (presetData.nodes || []).forEach((n) => {
-            const nodeService = {
+            const nodeService: DockerComposeService = {
                 image: presetData.symbolServerImage,
                 user,
                 command: `bash -c "/bin/bash /userconfig/runServerRecover.sh  ${n.name} && /bin/bash /userconfig/startServer.sh ${n.name}"`,
                 stop_signal: 'SIGINT',
-                depends_on: [] as string[],
+                depends_on: [],
                 restart: 'on-failure:2',
                 ports: n.openBrokerPort ? ['7900:7900'] : [],
                 volumes: [
@@ -87,8 +87,13 @@ export class ComposeService {
                     vol('../state', '/state'),
                 ],
             };
+            if (n.host) {
+                nodeService.hostname = n.host;
+                nodeService.networks = { default: { aliases: [n.host] } };
+            }
+
             if (n.databaseHost) {
-                nodeService.depends_on.push(n.databaseHost + '-init');
+                nodeService.depends_on?.push(n.databaseHost + '-init');
             }
             services[n.name] = nodeService;
             if (n.brokerHost) {
@@ -107,7 +112,7 @@ export class ComposeService {
                         vol('../state', '/state'),
                     ],
                 };
-                nodeService.depends_on.push(n.brokerHost);
+                nodeService.depends_on?.push(n.brokerHost);
             }
         });
 

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -20,7 +20,7 @@ export class ComposeService {
 
     constructor(private readonly root: string, protected readonly params: ComposeParams) {}
 
-    public async run(passedPresetData?: ConfigPreset): Promise<void> {
+    public async run(passedPresetData?: ConfigPreset): Promise<DockerCompose> {
         const presetData = passedPresetData ?? BootstrapUtils.loadExistingPresetData(this.params.target);
 
         const workingDir = process.cwd();
@@ -29,11 +29,10 @@ export class ComposeService {
         if (this.params.reset) {
             BootstrapUtils.deleteFolder(targetDocker);
         }
-
         const dockerFile = join(targetDocker, 'docker-compose.yml');
         if (fs.existsSync(dockerFile)) {
             logger.info(dockerFile + ' already exist. Reusing. (run -r to reset)');
-            return;
+            return BootstrapUtils.loadYaml(dockerFile);
         }
 
         await BootstrapUtils.mkdir(join(this.params.target, 'state'));
@@ -157,5 +156,6 @@ export class ComposeService {
 
         await BootstrapUtils.writeYaml(dockerFile, dockerCompose);
         logger.info(`docker-compose.yml file created ${dockerFile}`);
+        return dockerCompose;
     }
 }

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -412,15 +412,11 @@ export class ConfigService {
     }
 
     private async createVrfTransaction(presetData: ConfigPreset, node: NodeAccount): Promise<Transaction> {
-        const deadline = (Deadline as any)['createFromDTO']('1');
+        const deadline = Deadline.createFromDTO('1');
         const vrf = VrfKeyLinkTransaction.create(deadline, node.vrf.publicKey, LinkAction.Link, presetData.networkType, UInt64.fromUint(0));
         const account = Account.createFromPrivateKey(node.signing.privateKey, presetData.networkType);
         const signedTransaction = account.sign(vrf, presetData.nemesisGenerationHashSeed);
         return await this.storeTransaction(presetData, `vrf_${node.name}`, signedTransaction.payload);
-    }
-
-    private async createVotingKey(votingPublicKey: string): Promise<string> {
-        return votingPublicKey + '00000000000000000000000000000000';
     }
 
     private async createVotingKeyTransaction(presetData: ConfigPreset, node: NodeAccount): Promise<Transaction> {
@@ -428,7 +424,7 @@ export class ConfigService {
             throw new Error('Voting keys should have been generated!!');
         }
         const deadline = Deadline.createFromDTO('1');
-        const votingKey = await this.createVotingKey(node.voting.publicKey);
+        const votingKey = BootstrapUtils.createVotingKey(node.voting.publicKey);
         const voting = VotingKeyLinkTransaction.create(
             deadline,
             votingKey,

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -285,15 +285,14 @@ export class ConfigService {
                     return undefined;
                 }
                 const nodePresetData = (presetData.nodes || [])[index];
-                const name = node.name;
                 return {
                     publicKey: node.ssl.publicKey,
                     endpoint: {
-                        host: name,
+                        host: nodePresetData.host,
                         port: 7900,
                     },
                     metadata: {
-                        name: name,
+                        name: nodePresetData.friendlyName,
                         roles: nodePresetData.roles,
                     },
                 };

--- a/src/service/LinkService.ts
+++ b/src/service/LinkService.ts
@@ -1,0 +1,152 @@
+import Logger from '../logger/Logger';
+import LoggerFactory from '../logger/LoggerFactory';
+import { LogType } from '../logger/LogType';
+import {
+    Account,
+    Deadline,
+    LinkAction,
+    RepositoryFactoryHttp,
+    Transaction,
+    TransactionService,
+    UInt64,
+    VotingKeyLinkTransaction,
+    VrfKeyLinkTransaction,
+} from 'symbol-sdk';
+import { BootstrapUtils } from './BootstrapUtils';
+import * as _ from 'lodash';
+import { Addresses, ConfigPreset, NodeAccount } from '../model';
+import { catchError, map, mergeMap, toArray } from 'rxjs/operators';
+import { fromArray } from 'rxjs/internal/observable/fromArray';
+import { EMPTY, Observable, of } from 'rxjs';
+
+/**
+ * params necessary to announce link transactions network.
+ */
+export type LinkParams = { target: string; url: string; maxFee: number };
+
+const logger: Logger = LoggerFactory.getLogger(LogType.System);
+
+export class LinkService {
+    public static readonly defaultParams: LinkParams = { target: 'target', url: 'http://localhost:3000', maxFee: 100000 };
+
+    constructor(protected readonly params: LinkParams) {}
+
+    public async run(passedPresetData?: ConfigPreset | undefined, passedAddresses?: Addresses | undefined): Promise<void> {
+        const presetData = passedPresetData ?? BootstrapUtils.loadExistingPresetData(this.params.target);
+        const addresses = passedAddresses ?? BootstrapUtils.loadExistingAddresses(this.params.target);
+
+        const url = this.params.url.replace(/\/$/, '');
+        logger.info(`Linking nodes using network url ${url}. Max Fee ${this.params.maxFee}`);
+        const repositoryFactory = new RepositoryFactoryHttp(url);
+
+        const generationHash = await repositoryFactory.getGenerationHash().toPromise();
+        if (generationHash !== presetData.nemesisGenerationHashSeed) {
+            throw new Error(
+                `You are connecting to the wrong network. Expected generation hash is ${presetData.nemesisGenerationHashSeed} but got ${generationHash}`,
+            );
+        }
+
+        const transactionNodes: { node: NodeAccount; transactions: Transaction[] }[] = _.flatMap(addresses.nodes || []).map((node) => {
+            const transactions = [];
+            const account = Account.createFromPrivateKey(node.signing.privateKey, presetData.networkType);
+            if (node.voting) {
+                const votingPublicKey = BootstrapUtils.createVotingKey(node.voting.publicKey);
+                logger.info(
+                    `Creating VotingKeyLinkTransaction - node: ${node.name}, signer public key: ${account.publicKey}, voting public key: ${votingPublicKey}`,
+                );
+                transactions.push(
+                    VotingKeyLinkTransaction.create(
+                        Deadline.create(),
+                        votingPublicKey,
+                        1,
+                        26280,
+                        LinkAction.Link,
+                        presetData.networkType,
+                        UInt64.fromUint(100000),
+                    ),
+                );
+            }
+            logger.info(
+                `Creating VrfKeyLinkTransaction - node: ${node.name}, signer public key: ${account.publicKey}, vrf key: ${node.vrf.publicKey}`,
+            );
+            transactions.push(
+                VrfKeyLinkTransaction.create(
+                    Deadline.create(),
+                    node.vrf.publicKey,
+                    LinkAction.Link,
+                    presetData.networkType,
+                    UInt64.fromUint(100000),
+                ),
+            );
+            return { node, transactions };
+        });
+
+        if (!transactionNodes.length) {
+            logger.info(`There are no transactions no announce`);
+        }
+
+        const transactionRepository = repositoryFactory.createTransactionRepository();
+        const transactionService = new TransactionService(transactionRepository, repositoryFactory.createReceiptRepository());
+        const listener = repositoryFactory.createListener();
+        await listener.open();
+
+        const faucetUrl = 'http://faucet-0.10.0.x-01.symboldev.network/';
+
+        const signedTransactionObservable = fromArray(transactionNodes).pipe(
+            mergeMap(({ node, transactions }) => {
+                const account = Account.createFromPrivateKey(node.signing.privateKey, presetData.networkType);
+                return repositoryFactory
+                    .createAccountRepository()
+                    .getAccountInfo(account.address)
+                    .pipe(
+                        mergeMap((a) => {
+                            const mosaic = a.mosaics.find((m) => m.id.toHex().toLowerCase() === presetData.currencyMosaicId.toLowerCase());
+                            if (!mosaic || mosaic.amount.compare(UInt64.fromUint(0)) < 1) {
+                                logger.error(
+                                    `Node signing account ${account.address.plain()} doesn't not have enough currency. Mosaic id: ${
+                                        presetData.currencyMosaicId
+                                    }. \n\nDo do you need to assign some founds? Send some tokens to ${account.address.plain()}  You can try the latest faucet ${faucetUrl}`,
+                                );
+                                return EMPTY;
+                            }
+                            return fromArray(transactions.map((t) => account.sign(t, generationHash)));
+                        }),
+                        catchError((e) => {
+                            logger.error(
+                                `Node signing account ${account.address.plain()} is not valid. ${
+                                    e.message
+                                }. \n\nDo do you need to assign some founds? Send some tokens to ${account.address.plain()} You can try the latest faucet ${faucetUrl}`,
+                            );
+                            return EMPTY;
+                        }),
+                    );
+            }),
+        );
+
+        const announceCalls: Observable<string> = signedTransactionObservable.pipe(
+            mergeMap((signedTransaction) => {
+                return transactionService.announce(signedTransaction, listener).pipe(
+                    map((completedTransaction) => {
+                        const message = `Transaction ${completedTransaction.type} ${
+                            completedTransaction.transactionInfo?.hash
+                        } - signer ${completedTransaction.signer?.address.plain()} has been confirmed`;
+                        logger.info(message);
+                        return message;
+                    }),
+                    catchError((e) => {
+                        const message =
+                            `Transaction ${signedTransaction.type} ${
+                                signedTransaction.hash
+                            } - signer ${signedTransaction.getSignerAddress().plain()} failed!! ` + e.message;
+                        logger.error(message);
+                        return of(message);
+                    }),
+                );
+            }),
+        );
+
+        await announceCalls.pipe(toArray()).toPromise();
+
+        listener.close();
+    }
+}

--- a/src/service/NemgenService.ts
+++ b/src/service/NemgenService.ts
@@ -23,9 +23,9 @@ export class NemgenService {
         await promises.copyFile(`${this.root}/config/hashes.dat`, `${nemesisSeedFolder}/hashes.dat`);
 
         const cmd = [
-            'bash',
-            '-c',
-            'cd /data && /usr/catapult/bin/catapult.tools.nemgen  -r /userconfig --nemesisProperties /nemesis/block-properties-file.properties',
+            '/usr/catapult/bin/catapult.tools.nemgen',
+            '--resources=/userconfig',
+            '--nemesisProperties=/nemesis/block-properties-file.properties',
         ];
 
         if (!presetData.nodes) {
@@ -41,7 +41,13 @@ export class NemgenService {
         ];
 
         const userId = await BootstrapUtils.resolveDockerUserFromParam(this.params.user);
-        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec(symbolServerToolsImage, userId, cmd, binds);
+        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec({
+            image: symbolServerToolsImage,
+            userId: userId,
+            workdir: '/data',
+            cmds: cmd,
+            binds: binds,
+        });
 
         if (stdout.indexOf('<error> ') > -1) {
             logger.info(stdout);

--- a/src/service/VotingService.ts
+++ b/src/service/VotingService.ts
@@ -22,9 +22,12 @@ export class VotingService {
             const dir = `${process.cwd()}/${this.params.target}`;
             const votingKeysFolder = `${dir}/data/${nodeAccount.name}/votingkeys`;
             const cmd = [
-                'bash',
-                '-c',
-                `/usr/catapult/bin/catapult.tools.votingkey --secret ${nodeAccount.voting.privateKey} --output /votingKeys/${privateKeyTreeFileName}`,
+                '/usr/catapult/bin/catapult.tools.votingkey',
+                `--secret=${nodeAccount.voting.privateKey}`,
+                `--dilution=${presetData.votingKeyDilution}`,
+                `--startEpoch=${presetData.votingKeyStartEpoch}`,
+                `--endEpoch=${presetData.votingKeyEndEpoch}`,
+                `--output=/votingKeys/${privateKeyTreeFileName}`,
             ];
 
             await BootstrapUtils.mkdir(votingKeysFolder);
@@ -32,7 +35,12 @@ export class VotingService {
             const binds = [`${votingKeysFolder}:/votingKeys:rw`];
 
             const userId = await BootstrapUtils.resolveDockerUserFromParam(this.params.user);
-            const { stdout, stderr } = await BootstrapUtils.runImageUsingExec(symbolServerToolsImage, userId, cmd, binds);
+            const { stdout, stderr } = await BootstrapUtils.runImageUsingExec({
+                image: symbolServerToolsImage,
+                userId: userId,
+                cmds: cmd,
+                binds: binds,
+            });
 
             if (stdout.indexOf('<error> ') > -1) {
                 logger.info(stdout);

--- a/src/service/VotingService.ts
+++ b/src/service/VotingService.ts
@@ -14,14 +14,10 @@ const logger: Logger = LoggerFactory.getLogger(LogType.System);
 export class VotingService {
     constructor(protected readonly params: VotingParams) {}
 
-    private isVotingNode(n?: NodePreset): boolean {
-        return n!.roles.split(',').some((r) => r.trim() === 'Voting');
-    }
-
     public async run(presetData: ConfigPreset, nodeAccount: NodeAccount, nodePreset: NodePreset | undefined): Promise<void> {
         const symbolServerToolsImage = presetData.symbolServerToolsImage;
 
-        if (this.isVotingNode(nodePreset)) {
+        if (nodePreset?.voting && nodeAccount.voting) {
             const privateKeyTreeFileName = 'private_key_tree1.dat';
             const dir = `${process.cwd()}/${this.params.target}`;
             const votingKeysFolder = `${dir}/data/${nodeAccount.name}/votingkeys`;

--- a/test/custom_preset.yml
+++ b/test/custom_preset.yml
@@ -1,3 +1,3 @@
 nodes:
-  - voting: false
-  - voting: false
+    - voting: false
+    - voting: false

--- a/test/custom_preset.yml
+++ b/test/custom_preset.yml
@@ -1,0 +1,6 @@
+nodes:
+    - friendlyName: Peer Node 1 custom friendly name
+    - friendlyName: Peer Node 2 custom friendly name
+      host: 'peer2.custom.hostname'
+    - friendlyName: Api Node 1 custom friendly name
+      host: 'api1.custom.hostname'

--- a/test/custom_preset.yml
+++ b/test/custom_preset.yml
@@ -1,6 +1,3 @@
 nodes:
-    - friendlyName: Peer Node 1 custom friendly name
-    - friendlyName: Peer Node 2 custom friendly name
-      host: 'peer2.custom.hostname'
-    - friendlyName: Api Node 1 custom friendly name
-      host: 'api1.custom.hostname'
+  - voting: false
+  - voting: false

--- a/test/expected-testnet-dual-compose.yml
+++ b/test/expected-testnet-dual-compose.yml
@@ -1,0 +1,75 @@
+version: '3'
+networks:
+    default:
+        ipam:
+            config:
+                - subnet: 172.20.0.0/24
+services:
+    db:
+        image: 'mongo:4.2.6-bionic'
+        user: '1000:1000'
+        command: bash -c "mongod --dbpath=/dbdata --bind_ip=db"
+        stop_signal: SIGINT
+        ports: []
+        volumes:
+            - '../data/mongo:/dbdata:rw'
+    db-init:
+        image: 'mongo:4.2.6-bionic'
+        user: '1000:1000'
+        command: bash -c "/bin/bash /userconfig/mongors.sh && touch /state/mongo-is-setup"
+        volumes:
+            - './mongo:/userconfig/:ro'
+            - '../data/mongo:/dbdata:rw'
+            - '../state:/state'
+        depends_on:
+            - db
+    api-node:
+        image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
+        user: '1000:1000'
+        command: bash -c "/bin/bash /userconfig/runServerRecover.sh  api-node && /bin/bash /userconfig/startServer.sh api-node"
+        stop_signal: SIGINT
+        depends_on:
+            - db-init
+            - api-broker
+        restart: 'on-failure:2'
+        ports:
+            - '7900:7900'
+        volumes:
+            - './dockerfiles/catapult/userconfig/:/userconfig'
+            - './bin/bash:/bin-mount'
+            - '../config/api-node/resources/:/userconfig/resources/'
+            - '../data/api-node:/data:rw'
+            - '../data/nemesis-data:/nemesis-data:rw'
+            - '../state:/state'
+    api-broker:
+        image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
+        user: '1000:1000'
+        command: bash -c "/bin/bash /userconfig/runServerRecover.sh api-broker && /bin/bash /userconfig/startBroker.sh api-broker"
+        stop_signal: SIGINT
+        ports:
+            - '7902:7902'
+        restart: 'on-failure:2'
+        volumes:
+            - './dockerfiles/catapult/userconfig/:/userconfig'
+            - './bin/bash:/bin-mount'
+            - '../config/api-node/resources/:/userconfig/resources/'
+            - '../data/api-node:/data:rw'
+            - '../state:/state'
+    rest-gateway:
+        image: 'symbolplatform/symbol-rest:2.1.0'
+        user: '1000:1000'
+        command: ash -c "npm start /userconfig/rest.json"
+        stop_signal: SIGINT
+        ports:
+            - '3000:3000'
+        volumes:
+            - './bin/ash:/bin-mount'
+            - '../config/rest-gateway/:/userconfig/'
+            - '../state:/state'
+            - '../data/api-node/logs:/logs:rw'
+            - '../config/api-node/resources/:/usr/local/share/symbol/api-node-config/'
+        depends_on:
+            - db-init
+        networks:
+            default:
+                ipv4_address: 172.20.0.25

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -2,6 +2,7 @@ import 'mocha';
 import { BootstrapUtils, Preset } from '../../src/service';
 import assert = require('assert');
 import { expect } from '@oclif/test';
+import { Convert, Crypto } from 'symbol-sdk';
 
 describe('BootstrapUtils', () => {
     it('BootstrapUtils dockerUserId', async () => {
@@ -50,5 +51,13 @@ describe('BootstrapUtils', () => {
         expect(BootstrapUtils.toHex("0x5E62'990D'CAC5'BE8A")).to.be.eq("0x5E62'990D'CAC5'BE8A");
         expect(BootstrapUtils.toHex('0x5E62990DCAC5BE8A')).to.be.eq("0x5E62'990D'CAC5'BE8A");
         expect(BootstrapUtils.toHex("5E62'990D'CAC5'BE8A")).to.be.eq("0x5E62'990D'CAC5'BE8A");
+    });
+
+    it('createVotingKey', async () => {
+        expect(BootstrapUtils.createVotingKey('ABC')).to.be.eq(
+            'ABC000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+        );
+        const votingKey = Convert.uint8ToHex(Crypto.randomBytes(48));
+        expect(BootstrapUtils.createVotingKey(votingKey)).to.be.eq(votingKey);
     });
 });

--- a/test/service/ComposeService.test.ts
+++ b/test/service/ComposeService.test.ts
@@ -1,0 +1,27 @@
+import 'mocha';
+import { BootstrapService, BootstrapUtils, ConfigService, Preset } from '../../src/service';
+import { LinkService } from '../../src/service/LinkService';
+import { expect } from '@oclif/test';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+describe('ComposeService', () => {
+    it('Compose testnet', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-dual',
+            reset: false,
+            preset: Preset.testnet,
+            assembly: 'dual',
+        };
+
+        const service = new BootstrapService('.');
+        const configResult = await service.config(params);
+        const dockerCompose = await service.compose(params, configResult.presetData);
+        const targetDocker = join(params.target, `docker`, 'docker-compose.yml');
+        expect(existsSync(targetDocker)).to.be.true;
+        const expectedDockerCompose = BootstrapUtils.loadYaml('./test/expected-testnet-dual-compose.yml');
+        expect(dockerCompose).to.be.deep.eq(expectedDockerCompose);
+    });
+});

--- a/test/service/LinkService.test.ts
+++ b/test/service/LinkService.test.ts
@@ -1,0 +1,18 @@
+import 'mocha';
+import { BootstrapService, ConfigService, Preset } from '../../src/service';
+import { LinkService } from '../../src/service/LinkService';
+import { expect } from '@oclif/test';
+
+describe('LinkService', () => {
+    it('LinkService testnet', async () => {
+        const params = {
+            ...LinkService.defaultParams,
+            target: 'target/testnet-dual',
+        };
+        try {
+            await new BootstrapService('.').link(params);
+        } catch (e) {
+            expect(e.message.indexOf('ECONNREFUSED'), `Not a connection error: ${e.message}`).to.be.greaterThan(-1);
+        }
+    });
+});

--- a/test/service/LinkService.test.ts
+++ b/test/service/LinkService.test.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import { BootstrapService, ConfigService, Preset } from '../../src/service';
+import { BootstrapService } from '../../src/service';
 import { LinkService } from '../../src/service/LinkService';
 import { expect } from '@oclif/test';
 

--- a/test/service/LinkService.test.ts
+++ b/test/service/LinkService.test.ts
@@ -1,15 +1,20 @@
 import 'mocha';
-import { BootstrapService } from '../../src/service';
+import { BootstrapService, ConfigService, Preset } from '../../src/service';
 import { LinkService } from '../../src/service/LinkService';
 import { expect } from '@oclif/test';
 
 describe('LinkService', () => {
     it('LinkService testnet', async () => {
         const params = {
+            ...ConfigService.defaultParams,
             ...LinkService.defaultParams,
             target: 'target/testnet-dual',
+            reset: true,
+            preset: Preset.testnet,
+            assembly: 'dual',
         };
         try {
+            await new BootstrapService('.').config(params);
             await new BootstrapService('.').link(params);
         } catch (e) {
             expect(e.message.indexOf('ECONNREFUSED'), `Not a connection error: ${e.message}`).to.be.greaterThan(-1);

--- a/test/service/LinkService.test.ts
+++ b/test/service/LinkService.test.ts
@@ -2,14 +2,15 @@ import 'mocha';
 import { BootstrapService, ConfigService, Preset } from '../../src/service';
 import { LinkService } from '../../src/service/LinkService';
 import { expect } from '@oclif/test';
+import { TransactionType } from 'symbol-sdk';
 
 describe('LinkService', () => {
-    it('LinkService testnet', async () => {
+    it('LinkService testnet when down', async () => {
         const params = {
             ...ConfigService.defaultParams,
             ...LinkService.defaultParams,
             target: 'target/testnet-dual',
-            reset: true,
+            reset: false,
             preset: Preset.testnet,
             assembly: 'dual',
         };
@@ -19,5 +20,72 @@ describe('LinkService', () => {
         } catch (e) {
             expect(e.message.indexOf('ECONNREFUSED'), `Not a connection error: ${e.message}`).to.be.greaterThan(-1);
         }
+    });
+
+    it('LinkService create transactions when duak + voting', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-dual-voting',
+            reset: false,
+            preset: Preset.testnet,
+            customPreset: './test/voting_preset.yml',
+            assembly: 'dual',
+        };
+        const { addresses, presetData } = await new BootstrapService('.').config(params);
+        const nodeAndTransactions = await new LinkService(params).createTransactionsToAnnounce(addresses, presetData);
+        expect(nodeAndTransactions.length).eq(1);
+        expect(nodeAndTransactions[0].node).eq(addresses.nodes?.[0]);
+        expect(nodeAndTransactions[0].transactions.length).eq(2);
+        expect(nodeAndTransactions[0].transactions[0].type).eq(TransactionType.VRF_KEY_LINK);
+        expect(nodeAndTransactions[0].transactions[1].type).eq(TransactionType.VOTING_KEY_LINK);
+    });
+
+    it('LinkService create transactions when dual', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-dual',
+            reset: false,
+            preset: Preset.testnet,
+            assembly: 'dual',
+        };
+        const { addresses, presetData } = await new BootstrapService('.').config(params);
+        const nodeAndTransactions = await new LinkService(params).createTransactionsToAnnounce(addresses, presetData);
+        expect(nodeAndTransactions.length).eq(1);
+        expect(nodeAndTransactions[0].node).eq(addresses.nodes?.[0]);
+        expect(nodeAndTransactions[0].transactions.length).eq(1);
+        expect(nodeAndTransactions[0].transactions[0].type).eq(TransactionType.VRF_KEY_LINK);
+    });
+
+    it('LinkService create transactions when api', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-api',
+            reset: false,
+            preset: Preset.testnet,
+            assembly: 'api',
+        };
+        const { addresses, presetData } = await new BootstrapService('.').config(params);
+        const nodeAndTransactions = await new LinkService(params).createTransactionsToAnnounce(addresses, presetData);
+        expect(nodeAndTransactions.length).eq(0);
+    });
+
+    it('LinkService create transactions when api and voting', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-api-voting',
+            reset: false,
+            preset: Preset.testnet,
+            customPreset: './test/voting_preset.yml',
+            assembly: 'api',
+        };
+        const { addresses, presetData } = await new BootstrapService('.').config(params);
+        const nodeAndTransactions = await new LinkService(params).createTransactionsToAnnounce(addresses, presetData);
+        expect(nodeAndTransactions.length).eq(1);
+        expect(nodeAndTransactions[0].transactions.length).eq(1);
+        expect(nodeAndTransactions[0].transactions[0].type).eq(TransactionType.VOTING_KEY_LINK);
     });
 });

--- a/test/voting_preset.yml
+++ b/test/voting_preset.yml
@@ -1,3 +1,2 @@
 nodes:
-    - roles: 'Api,Peer,Voting'
-      voting: true
+    - voting: true

--- a/test/voting_preset.yml
+++ b/test/voting_preset.yml
@@ -1,3 +1,3 @@
 nodes:
-    - roles: 'Peer,Voting'
+    - roles: 'Api,Peer,Voting'
       voting: true

--- a/test/voting_preset.yml
+++ b/test/voting_preset.yml
@@ -1,0 +1,3 @@
+nodes:
+    - roles: 'Peer,Voting'
+      voting: true


### PR DESCRIPTION
Hi guys, I've created the `link` command.

This command automatically links the nodes keys (vrf and voting keys) to a running network.

The steps are the following:

For non-voting nodes (only VRF keys are linked)

```
symbol-bootstrap start -p testnet -a dual -r
... Assign tokens using faucet to the node signing key in addresses.yml...
... wait until start when using --detached or in another command line...
symbol-bootstrap link
```

For voting nodes (Voting and VRF keys are linked)
```
symbol-bootstrap start -p testnet -a peer -c customPreset.yml -r
... Assign tokens using faucet to the node signing key in  addresses.yml...
... wait until start when using --detached or in another command line...
symbol-bootstrap link
```

customPreset.yml
```
nodes:
    - voting: true
```

The link command does a bunch of validation. Try it without funds!!!

Link command also allows --url to tune the URL to another network node and --maxFee to tune the cost of the operations. You don't even have to have your node running to link the created configuration.


```
symbol-bootstrap config -p testnet -a dual -c customPreset.yml -r
... Assign tokens using faucet to the node signing key in  addresses.yml...
symbol-bootstrap link -u http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000/
```


Some other improvements:
- roles: is automatically created from the flags (we just need the voting flag to enable voting)
- Improved Readme and custom preset examples
- Added custom host configuration in docker-compose.

Note: I'm not creating a voting assembly as there could be 3 more to maintain (API + voting, peer + voting and dual + voting).
I think most people would need to create a custom preset anyway when running testnet nodes.

 -r is to clean up the target folder if you are trying multiple configurations
