### PR TITLE
Report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ $ npm install -g symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (-v|--version|version)
-symbol-bootstrap/0.1.1 linux-x64 node-v12.18.4
+symbol-bootstrap/0.1.1 linux-x64 node-v14.8.0
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ $ npm install -g symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (-v|--version|version)
-symbol-bootstrap/0.1.1 linux-x64 node-v14.8.0
+symbol-bootstrap/0.1.1 linux-x64 node-v12.18.4
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND
@@ -368,6 +368,7 @@ General users should install this tool like any other node module.
 * [`symbol-bootstrap config`](docs/config.md) - Command used to set up the configuration files and the nemesis block for the current network
 * [`symbol-bootstrap help`](docs/help.md) - display help for symbol-bootstrap
 * [`symbol-bootstrap link`](docs/link.md) - It announces VRF and Voting Link transactions to the network for each node with 'Peer' or 'Voting' roles. This command finalizes the node registration to an existing network.
+* [`symbol-bootstrap report`](docs/report.md) - it generates reStructuredText (.rst) reports describing the configuration of each node.
 * [`symbol-bootstrap run`](docs/run.md) - It boots the network via docker using the generated `docker-compose.yml` file and configuration. The config and compose methods/commands need to be called before this method. This is just a wrapper for the `docker-compose up` bash call.
 * [`symbol-bootstrap start`](docs/start.md) - Single command that aggregates config, compose and run in one line!
 * [`symbol-bootstrap stop`](docs/stop.md) - It stops the docker-compose network if running (symbol-bootstrap started with --detached). This is just a wrapper for the `docker-compose down` bash call.

--- a/config/node/resources/config-harvesting.properties.mustache
+++ b/config/node/resources/config-harvesting.properties.mustache
@@ -3,7 +3,7 @@
 harvesterSigningPrivateKey = {{{harvesterSigningPrivateKey}}}
 harvesterVrfPrivateKey = {{{harvesterVrfPrivateKey}}}
 
-enableAutoHarvesting = true
-maxUnlockedAccounts = 5
-delegatePrioritizationPolicy = Importance
-beneficiaryAddress =
+enableAutoHarvesting = {{{enableAutoHarvesting}}}
+maxUnlockedAccounts = {{{maxUnlockedAccounts}}}
+delegatePrioritizationPolicy = {{{delegatePrioritizationPolicy}}}
+beneficiaryAddress = {{{beneficiaryAddress}}}

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,6 +30,9 @@ OPTIONS
   -u, --user=user                         [default: current] User used to run docker images when creating configuration
                                           files like certificates or nemesis block. "current" means the current user.
 
+  --report                                It generates reStructuredText (.rst) reports describing the configuration of
+                                          each node.
+
 EXAMPLE
   $ symbol-bootstrap config -p bootstrap
 ```

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,0 +1,24 @@
+`symbol-bootstrap report`
+=========================
+
+it generates reStructuredText (.rst) reports describing the configuration of each node.
+
+* [`symbol-bootstrap report`](#symbol-bootstrap-report)
+
+## `symbol-bootstrap report`
+
+it generates reStructuredText (.rst) reports describing the configuration of each node.
+
+```
+USAGE
+  $ symbol-bootstrap report
+
+OPTIONS
+  -h, --help           It shows the help of this command.
+  -t, --target=target  [default: target] The target folder where the configuration was generated
+
+EXAMPLE
+  $ symbol-bootstrap report
+```
+
+_See code: [src/commands/report.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.1.1/src/commands/report.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -40,6 +40,9 @@ OPTIONS
   -u, --user=user                         [default: current] User used to run docker images when creating configuration
                                           files like certificates or nemesis block. "current" means the current user.
 
+  --report                                It generates reStructuredText (.rst) reports describing the configuration of
+                                          each node.
+
 EXAMPLES
   $ symbol-bootstrap start
   $ symbol-bootstrap start -p bootstrap

--- a/presets/descriptions.yml
+++ b/presets/descriptions.yml
@@ -155,9 +155,11 @@ Property:
 harvesterSigningPrivateKey:
     type: string
     description: Harvester signing private key.
+    hidden: true
 harvesterVrfPrivateKey:
     type: string
     description: Harvester vrf private key.
+    hidden: true
 enableAutoHarvesting:
     type: bool
     description: Set to true if auto harvesting is enabled.
@@ -365,3 +367,214 @@ maxMosaicRestrictionValues:
 maxMessageSize:
     type: uint16_t
     description: Maximum transaction message size.
+#    Complete the following:
+databaseUri:
+    type: ''
+    description: ''
+databaseName:
+    type: ''
+    description: ''
+maxWriterThreads:
+    type: ''
+    description: ''
+catapult.mongo.plugins.accountlink:
+    type: ''
+    description: ''
+catapult.mongo.plugins.aggregate:
+    type: ''
+    description: ''
+catapult.mongo.plugins.lockhash:
+    type: ''
+    description: ''
+catapult.mongo.plugins.locksecret:
+    type: ''
+    description: ''
+catapult.mongo.plugins.metadata:
+    type: ''
+    description: ''
+catapult.mongo.plugins.mosaic:
+    type: ''
+    description: ''
+catapult.mongo.plugins.multisig:
+    type: ''
+    description: ''
+catapult.mongo.plugins.namespace:
+    type: ''
+    description: ''
+catapult.mongo.plugins.restrictionaccount:
+    type: ''
+    description: ''
+catapult.mongo.plugins.restrictionmosaic:
+    type: ''
+    description: ''
+catapult.mongo.plugins.transfer:
+    type: ''
+    description: ''
+extension.addressextraction:
+    type: ''
+    description: ''
+extension.mongo:
+    type: ''
+    description: ''
+extension.zeromq:
+    type: ''
+    description: ''
+extension.hashcache:
+    type: ''
+    description: ''
+extension.filespooling:
+    type: ''
+    description: ''
+extension.partialtransaction:
+    type: ''
+    description: ''
+extension.eventsource:
+    type: ''
+    description: ''
+extension.harvesting:
+    type: ''
+    description: ''
+extension.syncsource:
+    type: ''
+    description: ''
+extension.diagnostics:
+    type: ''
+    description: ''
+extension.finalization:
+    type: ''
+    description: ''
+extension.networkheight:
+    type: ''
+    description: ''
+extension.nodediscovery:
+    type: ''
+    description: ''
+extension.packetserver:
+    type: ''
+    description: ''
+extension.pluginhandlers:
+    type: ''
+    description: ''
+extension.sync:
+    type: ''
+    description: ''
+extension.timesync:
+    type: ''
+    description: ''
+extension.transactionsink:
+    type: ''
+    description: ''
+extension.unbondedpruning:
+    type: ''
+    description: ''
+enableVoting:
+    type: ''
+    description: ''
+size:
+    type: ''
+    description: ''
+threshold:
+    type: ''
+    description: ''
+stepDuration:
+    type: ''
+    description: ''
+shortLivedCacheMessageDuration:
+    type: ''
+    description: ''
+messageSynchronizationMaxResponseSize:
+    type: ''
+    description: ''
+maxHashesPerPoint:
+    type: ''
+    description: ''
+prevoteBlocksMultiple:
+    type: ''
+    description: ''
+votingKeyDilution:
+    type: ''
+    description: ''
+sinkType:
+    type: ''
+    description: ''
+level:
+    type: ''
+    description: ''
+colorMode:
+    type: ''
+    description: ''
+directory:
+    type: ''
+    description: ''
+filePattern:
+    type: ''
+    description: ''
+rotationSize:
+    type: ''
+    description: ''
+maxTotalSize:
+    type: ''
+    description: ''
+minFreeSpace:
+    type: ''
+    description: ''
+subscriberPort:
+    type: ''
+    description: ''
+generationHashSeed:
+    type: ''
+    description: ''
+votingSetGrouping:
+    type: ''
+    description: ''
+dummy:
+    type: ''
+    description: ''
+maxNodes:
+    type: ''
+    description: ''
+maxHashesPerSyncAttempt:
+    type: ''
+    description: ''
+cacheMaxResponseSize:
+    type: ''
+    description: ''
+cacheMaxSize:
+    type: ''
+    description: ''
+startDelay:
+    type: ''
+    description: ''
+repeatDelay:
+    type: ''
+    description: ''
+minDelay:
+    type: ''
+    description: ''
+maxDelay:
+    type: ''
+    description: ''
+numPhaseOneRounds:
+    type: ''
+    description: ''
+numTransitionRounds:
+    type: ''
+    description: ''
+minImportance:
+    type: ''
+    description: ''
+enableDelegatedHarvestersAutoDetection:
+    type: ''
+    description: ''
+certificateDirectory:
+    type: ''
+    description: ''
+dataDirectory:
+    type: ''
+    description: ''
+pluginsDirectory:
+    type: ''
+    description: ''
+votingKeysDirectory:
+    type: ''
+    description: ''

--- a/presets/descriptions.yml
+++ b/presets/descriptions.yml
@@ -1,0 +1,367 @@
+port:
+    type: unsigned short
+    description: Server port.
+maxIncomingConnectionsPerIdentity:
+    type: uint32_t
+    description: Maximum number of incoming connections per identity over primary port.
+enableAddressReuse:
+    type: bool
+    description: Set to true if the server should reuse ports already in use.
+enableSingleThreadPool:
+    type: bool
+    description: 'Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used.'
+enableCacheDatabaseStorage:
+    type: bool
+    description: Set to true if cache data should be saved in a database.
+enableAutoSyncCleanup:
+    type: bool
+    description: "Set to true if temporary sync files should be automatically cleaned up.\_Note: This should be Set to false if broker process is running."
+enableTransactionSpamThrottling:
+    type: bool
+    description: Set to true if transaction spam throttling should be enabled.
+transactionSpamThrottlingMaxBoostFee:
+    type: Amount
+    description: Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled.
+maxBlocksPerSyncAttempt:
+    type: uint32_t
+    description: Maximum number of blocks per sync attempt.
+maxChainBytesPerSyncAttempt:
+    type: 'utils::FileSize'
+    description: Maximum chain bytes per sync attempt.
+shortLivedCacheTransactionDuration:
+    type: 'utils::TimeSpan'
+    description: Duration of a transaction in the short lived cache.
+shortLivedCacheBlockDuration:
+    type: 'utils::TimeSpan'
+    description: Duration of a block in the short lived cache.
+shortLivedCachePruneInterval:
+    type: 'utils::TimeSpan'
+    description: Time between short lived cache pruning.
+shortLivedCacheMaxSize:
+    type: uint32_t
+    description: Maximum size of a short lived cache.
+minFeeMultiplier:
+    type: BlockFeeMultiplier
+    description: Minimum fee multiplier of transactions to propagate and include in blocks.
+transactionSelectionStrategy:
+    type: 'model::TransactionSelectionStrategy'
+    description: Transaction selection strategy used for syncing and harvesting unconfirmed transactions.
+unconfirmedTransactionsCacheMaxResponseSize:
+    type: 'utils::FileSize'
+    description: Maximum size of an unconfirmed transactions response.
+unconfirmedTransactionsCacheMaxSize:
+    type: uint32_t
+    description: Maximum size of the unconfirmed transactions cache.
+connectTimeout:
+    type: 'utils::TimeSpan'
+    description: Timeout for connecting to a peer.
+syncTimeout:
+    type: 'utils::TimeSpan'
+    description: Timeout for syncing with a peer.
+socketWorkingBufferSize:
+    type: 'utils::FileSize'
+    description: Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size).
+socketWorkingBufferSensitivity:
+    type: uint32_t
+    description: "Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed).\_Note: Set to 0 will disable memory reclamation."
+maxPacketDataSize:
+    type: 'utils::FileSize'
+    description: Maximum packet data size.
+blockDisruptorSize:
+    type: uint32_t
+    description: Size of the block disruptor circular buffer.
+blockElementTraceInterval:
+    type: uint32_t
+    description: Multiple of elements at which a block element should be traced through queue and completion.
+transactionDisruptorSize:
+    type: uint32_t
+    description: Size of the transaction disruptor circular buffer.
+transactionElementTraceInterval:
+    type: uint32_t
+    description: Multiple of elements at which a transaction element should be traced through queue and completion.
+enableDispatcherAbortWhenFull:
+    type: bool
+    description: Set to true if the process should terminate when any dispatcher is full.
+enableDispatcherInputAuditing:
+    type: bool
+    description: Set to true if all dispatcher inputs should be audited.
+maxCacheDatabaseWriteBatchSize:
+    type: 'utils::FileSize'
+    description: Maximum cache database write batch size.
+maxTrackedNodes:
+    type: uint32_t
+    description: Maximum number of nodes to track in memory.
+batchVerificationRandomSource:
+    type: string
+    description: Source of random numbers used in batch verification.
+trustedHosts:
+    type: unordered_set<string>
+    description: Trusted hosts that are allowed to execute protected API calls on this node.
+localNetworks:
+    type: unordered_set<string>
+    description: Networks that should be treated as local.
+host:
+    type: string
+    description: Node host (leave empty to auto-detect IP).
+friendlyName:
+    type: string
+    description: Node friendly name (leave empty to use address).
+version:
+    type: uint32_t
+    description: Node version.
+roles:
+    type: 'ionet::NodeRoles'
+    description: Node roles.
+maxConnections:
+    type: uint16_t
+    description: Maximum number of active connections.
+maxConnectionAge:
+    type: uint16_t
+    description: Maximum connection age.
+maxConnectionBanAge:
+    type: uint16_t
+    description: Maximum connection ban age.
+numConsecutiveFailuresBeforeBanning:
+    type: uint16_t
+    description: Number of consecutive connection failures before a connection is banned.
+backlogSize:
+    type: uint16_t
+    description: Maximum size of the pending connections queue.
+defaultBanDuration:
+    type: 'utils::TimeSpan'
+    description: Default duration for banning.
+maxBanDuration:
+    type: 'utils::TimeSpan'
+    description: Maximum duration for banning.
+keepAliveDuration:
+    type: 'utils::TimeSpan'
+    description: Duration to keep account in container after the ban expired.
+maxBannedNodes:
+    type: uint32_t
+    description: Maximum number of banned nodes.
+numReadRateMonitoringBuckets:
+    type: uint16_t
+    description: Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring).
+readRateMonitoringBucketDuration:
+    type: 'utils::TimeSpan'
+    description: Duration of each read rate monitoring bucket.
+maxReadRateMonitoringTotalSize:
+    type: 'utils::FileSize'
+    description: Maximum size allowed during full read rate monitoring period.
+config-harvesting.properties: {}
+Property:
+    type: Type
+    description: Description
+harvesterSigningPrivateKey:
+    type: string
+    description: Harvester signing private key.
+harvesterVrfPrivateKey:
+    type: string
+    description: Harvester vrf private key.
+enableAutoHarvesting:
+    type: bool
+    description: Set to true if auto harvesting is enabled.
+maxUnlockedAccounts:
+    type: uint32_t
+    description: Maximum number of unlocked accounts.
+delegatePrioritizationPolicy:
+    type: 'harvesting::DelegatePrioritizationPolicy'
+    description: Delegate harvester prioritization policy.
+beneficiaryAddress:
+    type: Address
+    description: Address of the account receiving part of the harvested fee.
+identifier:
+    type: NetworkIdentifier
+    description: Network identifier.
+nodeEqualityStrategy:
+    type: NodeIdentityEqualityStrategy
+    description: Node equality strategy.
+nemesisSignerPublicKey:
+    type: Key
+    description: Nemesis public key.
+generationHash:
+    type: 'catapult::GenerationHash'
+    description: Nemesis generation hash.
+epochAdjustment:
+    type: 'utils::TimeSpan'
+    description: Nemesis epoch time adjustment.
+enableVerifiableState:
+    type: bool
+    description: Set to true if block chain should calculate state hashes so that state is fully verifiable at each block.
+enableVerifiableReceipts:
+    type: bool
+    description: Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block.
+currencyMosaicId:
+    type: MosaicId
+    description: Mosaic id used as primary chain currency.
+harvestingMosaicId:
+    type: MosaicId
+    description: Mosaic id used to provide harvesting ability.
+blockGenerationTargetTime:
+    type: 'utils::TimeSpan'
+    description: Targeted time between blocks.
+blockTimeSmoothingFactor:
+    type: uint32_t
+    description: "Note: A higher value makes the network more biased.\_Note: This can lower security because it will increase the influence of time relative to importance."
+blockFinalizationInterval:
+    type: uint32_t
+    description: Number of blocks between successive finalization attempts.
+importanceGrouping:
+    type: uint64_t
+    description: "Number of blocks that should be treated as a group for importance purposes.\_Note: Importances will only be calculated at blocks that are multiples of this grouping number."
+importanceActivityPercentage:
+    type: uint8_t
+    description: Percentage of importance resulting from fee generation and beneficiary usage.
+maxRollbackBlocks:
+    type: uint32_t
+    description: Maximum number of blocks that can be rolled back.
+maxDifficultyBlocks:
+    type: uint32_t
+    description: Maximum number of blocks to use in a difficulty calculation.
+defaultDynamicFeeMultiplier:
+    type: BlockFeeMultiplier
+    description: Default multiplier to use for dynamic fees.
+maxTransactionLifetime:
+    type: 'utils::TimeSpan'
+    description: Maximum lifetime a transaction can have before it expires.
+maxBlockFutureTime:
+    type: 'utils::TimeSpan'
+    description: Maximum future time of a block that can be accepted.
+initialCurrencyAtomicUnits:
+    type: Amount
+    description: Initial currency atomic units available in the network.
+maxMosaicAtomicUnits:
+    type: Amount
+    description: Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network.
+totalChainImportance:
+    type: Importance
+    description: Total whole importance units available in the network.
+minHarvesterBalance:
+    type: Amount
+    description: Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+maxHarvesterBalance:
+    type: Amount
+    description: Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+minVoterBalance:
+    type: Amount
+    description: Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting.
+maxVotingKeysPerAccount:
+    type: uint8_t
+    description: Maximum number of voting keys that can be registered at once per account.
+minVotingKeyLifetime:
+    type: uint32_t
+    description: Minimum number of finalization rounds for which voting key can be registered.
+maxVotingKeyLifetime:
+    type: uint32_t
+    description: Maximum number of finalization rounds for which voting key can be registered.
+harvestBeneficiaryPercentage:
+    type: uint8_t
+    description: Percentage of the harvested fee that is collected by the beneficiary account.
+harvestNetworkPercentage:
+    type: uint8_t
+    description: Percentage of the harvested fee that is collected by the network.
+harvestNetworkFeeSinkAddress:
+    type: Address
+    description: Address of the harvest network fee sink account.
+blockPruneInterval:
+    type: uint32_t
+    description: Number of blocks between cache pruning.
+maxTransactionsPerBlock:
+    type: uint32_t
+    description: Maximum number of transactions per block.
+maxTransactionsPerAggregate:
+    type: uint32_t
+    description: Maximum number of transactions per aggregate.
+maxCosignaturesPerAggregate:
+    type: uint8_t
+    description: Maximum number of cosignatures per aggregate.
+enableStrictCosignatureCheck:
+    type: bool
+    description: Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally.
+enableBondedAggregateSupport:
+    type: bool
+    description: Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected.
+maxBondedTransactionLifetime:
+    type: 'utils::TimeSpan'
+    description: Maximum lifetime a bonded transaction can have before it expires.
+lockedFundsPerAggregate:
+    type: Amount
+    description: Amount that has to be locked per aggregate in partial cache.
+maxHashLockDuration:
+    type: 'utils::BlockSpan'
+    description: Maximum number of blocks for which a hash lock can exist.
+maxSecretLockDuration:
+    type: 'utils::BlockSpan'
+    description: Maximum number of blocks for which a secret lock can exist.
+minProofSize:
+    type: uint16_t
+    description: Minimum size of a proof in bytes.
+maxProofSize:
+    type: uint16_t
+    description: Maximum size of a proof in bytes.
+maxValueSize:
+    type: uint16_t
+    description: Maximum metadata value size.
+maxMosaicsPerAccount:
+    type: uint16_t
+    description: Maximum number of mosaics that an account can own.
+maxMosaicDuration:
+    type: 'utils::BlockSpan'
+    description: Maximum mosaic duration.
+maxMosaicDivisibility:
+    type: uint8_t
+    description: Maximum mosaic divisibility.
+mosaicRentalFeeSinkAddress:
+    type: Address
+    description: Address of the mosaic rental fee sink account.
+mosaicRentalFee:
+    type: Amount
+    description: Mosaic rental fee.
+maxMultisigDepth:
+    type: uint8_t
+    description: Maximum number of multisig levels.
+maxCosignatoriesPerAccount:
+    type: uint32_t
+    description: Maximum number of cosignatories per account.
+maxCosignedAccountsPerAccount:
+    type: uint32_t
+    description: Maximum number of accounts a single account can cosign.
+maxNameSize:
+    type: uint8_t
+    description: Maximum namespace name size.
+maxChildNamespaces:
+    type: uint16_t
+    description: Maximum number of children for a root namespace.
+maxNamespaceDepth:
+    type: uint8_t
+    description: Maximum namespace depth.
+minNamespaceDuration:
+    type: 'utils::BlockSpan'
+    description: Minimum namespace duration.
+maxNamespaceDuration:
+    type: 'utils::BlockSpan'
+    description: Maximum namespace duration.
+namespaceGracePeriodDuration:
+    type: 'utils::BlockSpan'
+    description: Grace period during which time only the previous owner can renew an expired namespace.
+reservedRootNamespaceNames:
+    type: unordered_set<string>
+    description: Reserved root namespaces that cannot be claimed.
+namespaceRentalFeeSinkAddress:
+    type: Address
+    description: Address of the namespace rental fee sink account.
+rootNamespaceRentalFeePerBlock:
+    type: Amount
+    description: Root namespace rental fee per block.
+childNamespaceRentalFee:
+    type: Amount
+    description: Child namespace rental fee.
+maxAccountRestrictionValues:
+    type: uint16_t
+    description: Maximum number of account restriction values.
+maxMosaicRestrictionValues:
+    type: uint8_t
+    description: Maximum number of mosaic restriction values.
+maxMessageSize:
+    type: uint16_t
+    description: Maximum transaction message size.

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -98,6 +98,11 @@ enableDispatcherAbortWhenFull: false
 enableDispatcherInputAuditing: false
 maxCacheDatabaseWriteBatchSize: 5MB
 maxTrackedNodes: 5'000
+beneficiaryAddress:
+enableAutoHarvesting: true
+maxUnlockedAccounts: 5
+delegatePrioritizationPolicy: Importance
+
 
 outgoing_connections_maxConnections: 10
 outgoing_connections_maxConnectionAge: 200

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -33,6 +33,12 @@ export default class Config extends Command {
             description: 'It resets the configuration generating a new one',
             default: ConfigService.defaultParams.reset,
         }),
+
+        report: flags.boolean({
+            description: 'It generates reStructuredText (.rst) reports describing the configuration of each node.',
+            default: ConfigService.defaultParams.report,
+        }),
+
         user: flags.string({
             char: 'u',
             description: `User used to run docker images when creating configuration files like certificates or nemesis block. "${BootstrapUtils.CURRENT_USER}" means the current user.`,

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,23 @@
+import { Command, flags } from '@oclif/command';
+import { BootstrapService, BootstrapUtils, ConfigService } from '../service';
+
+export default class Clean extends Command {
+    static description = 'it generates reStructuredText (.rst) reports describing the configuration of each node.';
+
+    static examples = [`$ symbol-bootstrap report`];
+
+    static flags = {
+        help: flags.help({ char: 'h', description: 'It shows the help of this command.' }),
+        target: flags.string({
+            char: 't',
+            description: 'The target folder where the configuration was generated',
+            default: ConfigService.defaultParams.target,
+        }),
+    };
+
+    public async run(): Promise<void> {
+        const { flags } = this.parse(Clean);
+        BootstrapUtils.showBanner();
+        await new BootstrapService(this.config.root).report(flags);
+    }
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { Command, flags } from '@oclif/command';
-import { BootstrapUtils, ConfigService, RunService } from '../service';
+import { BootstrapService, BootstrapUtils, ConfigService, RunService } from '../service';
 
 export default class Run extends Command {
     static description =
@@ -38,6 +38,6 @@ export default class Run extends Command {
     public run(): Promise<void> {
         const { flags } = this.parse(Run);
         BootstrapUtils.showBanner();
-        return new RunService(flags).run();
+        return new BootstrapService(this.config.root).run(flags);
     }
 }

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -40,6 +40,10 @@ export interface NodePreset {
     roles: string;
     friendlyName?: string;
     brokerHost?: string;
+    // Optional private keys. If not provided, bootstrap will generate random ones.
+    signingPrivateKey?: string;
+    vrfPrivateKey?: string;
+    votingPrivateKey?: string;
 }
 
 export interface GatewayPreset {

--- a/src/service/BootstrapService.ts
+++ b/src/service/BootstrapService.ts
@@ -2,6 +2,7 @@ import { ConfigParams, ConfigResult, ConfigService } from './ConfigService';
 import { ComposeParams, ComposeService } from './ComposeService';
 import { RunParams, RunService } from './RunService';
 import { BootstrapUtils } from './BootstrapUtils';
+import { ReportParams, ReportService } from './ReportService';
 import { Addresses, ConfigPreset } from '../model';
 import { LinkParams, LinkService } from './LinkService';
 import { DockerCompose } from '../model/DockerCompose';
@@ -51,6 +52,19 @@ export class BootstrapService {
         passedAddresses?: Addresses | undefined,
     ): Promise<void> {
         await new LinkService(config).run(passedPresetData, passedAddresses);
+    }
+
+    /**
+     * It generates reStructuredText (.rst) reports describing the configuration of each node.
+     *
+     * The config method/command needs to be called before this method
+     *
+     * @param config the params of the report command.
+     * @param passedPresetData the created preset if you know if, otherwise will load the latest one resolved from the target folder.
+     * @return the paths of the created reports.
+     */
+    public async report(config: ReportParams = ReportService.defaultParams, passedPresetData?: ConfigPreset): Promise<string[]> {
+        return await new ReportService(this.root, config).run(passedPresetData);
     }
 
     /**

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -35,6 +35,7 @@ export class CertificateService {
             this.params.preset,
             this.params.assembly,
             this.params.customPreset,
+            this.params.customPresetObject,
         );
         const symbolServerToolsImage = presetData.symbolServerToolsImage;
         const copyFrom = `${this.root}/config/cert`;

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -23,6 +23,7 @@ import { Addresses, ConfigAccount, ConfigPreset, NodeAccount, NodePreset, NodeTy
 import * as fs from 'fs';
 import { VotingService } from './VotingService';
 import { join } from 'path';
+import { ReportService } from './ReportService';
 
 /**
  * Defined presets.
@@ -34,12 +35,14 @@ export enum Preset {
 }
 
 export interface ConfigParams {
+    report: boolean;
     reset: boolean;
     preset: Preset;
     target: string;
     user: string;
     assembly?: string;
     customPreset?: string;
+    customPresetObject?: any;
 }
 
 export interface ConfigResult {
@@ -52,6 +55,7 @@ const logger: Logger = LoggerFactory.getLogger(LogType.System);
 export class ConfigService {
     public static defaultParams: ConfigParams = {
         target: 'target',
+        report: false,
         preset: Preset.bootstrap,
         reset: false,
         user: BootstrapUtils.CURRENT_USER,
@@ -106,9 +110,14 @@ export class ConfigService {
         const friendlyName = node.friendlyName || ssl.publicKey.substr(0, 7);
         const roles = this.resolveRoles(node);
         const nodeAccount: NodeAccount = { type, name, friendlyName, roles: roles, ssl };
-        if (node.harvesting || node.voting) nodeAccount.signing = this.toConfig(Account.generateNewAccount(networkType));
-        if (node.voting) nodeAccount.voting = this.toConfig(Account.generateNewAccount(networkType));
-        if (node.harvesting) nodeAccount.vrf = this.toConfig(Account.generateNewAccount(networkType));
+
+      const generateAccount = (networkType: NetworkType, privateKey: string | undefined): Account =>
+        privateKey ? Account.createFromPrivateKey(privateKey, networkType) : Account.generateNewAccount(networkType);
+
+
+      if (node.harvesting || node.voting) nodeAccount.signing = this.toConfig(generateAccount(networkType, node.s));
+        if (node.voting) nodeAccount.voting = this.toConfig(generateAccount(networkType));
+        if (node.harvesting) nodeAccount.vrf = this.toConfig(generateAccount(networkType));
         return nodeAccount;
     }
 
@@ -142,6 +151,7 @@ export class ConfigService {
             this.params.preset,
             this.params.assembly,
             this.params.customPreset,
+            this.params.customPresetObject,
         );
 
         await fs.promises.mkdir(`${this.params.target}/config/generated-addresses`, { recursive: true });
@@ -159,6 +169,10 @@ export class ConfigService {
             const copyFrom = presetData.nemesisSeedFolder || `${this.root}/presets/${this.params.preset}/seed`;
             const copyTo = `${this.params.target}/data/nemesis-data/seed`;
             await BootstrapUtils.generateConfiguration({}, copyFrom, copyTo);
+        }
+
+        if (this.params.report) {
+            await new ReportService(this.root, this.params).run(presetData);
         }
 
         await BootstrapUtils.writeYaml(`${this.params.target}/config/preset.yml`, presetData);

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -111,13 +111,12 @@ export class ConfigService {
         const roles = this.resolveRoles(node);
         const nodeAccount: NodeAccount = { type, name, friendlyName, roles: roles, ssl };
 
-      const generateAccount = (networkType: NetworkType, privateKey: string | undefined): Account =>
-        privateKey ? Account.createFromPrivateKey(privateKey, networkType) : Account.generateNewAccount(networkType);
+        const generateAccount = (networkType: NetworkType, privateKey: string | undefined): Account =>
+            privateKey ? Account.createFromPrivateKey(privateKey, networkType) : Account.generateNewAccount(networkType);
 
-
-      if (node.harvesting || node.voting) nodeAccount.signing = this.toConfig(generateAccount(networkType, node.s));
-        if (node.voting) nodeAccount.voting = this.toConfig(generateAccount(networkType));
-        if (node.harvesting) nodeAccount.vrf = this.toConfig(generateAccount(networkType));
+        if (node.harvesting || node.voting) nodeAccount.signing = this.toConfig(generateAccount(networkType, node.signingPrivateKey));
+        if (node.voting) nodeAccount.voting = this.toConfig(generateAccount(networkType, node.votingPrivateKey));
+        if (node.harvesting) nodeAccount.vrf = this.toConfig(generateAccount(networkType, node.vrfPrivateKey));
         return nodeAccount;
     }
 

--- a/src/service/ReportService.ts
+++ b/src/service/ReportService.ts
@@ -5,9 +5,34 @@ import { BootstrapUtils } from './BootstrapUtils';
 import { ConfigPreset } from '../model';
 import { join } from 'path';
 import { promises as fsPromises, readFileSync } from 'fs';
+import _ = require('lodash');
+
 export type ReportParams = { target: string };
 
 const logger: Logger = LoggerFactory.getLogger(LogType.System);
+
+interface ReportLine {
+    property: string;
+    type: string;
+    description: string;
+    hidden: boolean;
+    value: string;
+}
+
+interface ReportSection {
+    header: string;
+    lines: ReportLine[];
+}
+
+interface ReportFile {
+    fileName: string;
+    sections: ReportSection[];
+}
+
+interface ReportNode {
+    name: string;
+    files: ReportFile[];
+}
 
 export class ReportService {
     public static defaultParams: ReportParams = {
@@ -16,6 +41,71 @@ export class ReportService {
 
     constructor(private readonly root: string, protected readonly params: ReportParams) {}
 
+    private createReportFromFile(resourceContent: string, descriptions: any): ReportSection[] {
+        const sections: ReportSection[] = [];
+
+        const lines = resourceContent
+            .trim()
+            .split(/\s*[\r\n]+\s*/g)
+            .map((l) => l.trim())
+            .filter((l) => l && l.indexOf('#') != 0);
+
+        lines.forEach((l) => {
+            const isHeader = /\[(.*?)\]/.exec(l);
+            if (isHeader && isHeader.length && isHeader[1]) {
+                sections.push({
+                    header: isHeader[1],
+                    lines: [],
+                });
+            } else {
+                const isProperty = /(.*)=(.*)/.exec(l);
+                if (isProperty && isProperty.length && isProperty[1]) {
+                    const propertyName = isProperty[1].trim();
+                    const descriptor = descriptions[propertyName];
+                    const hidden = (descriptor && descriptor.hidden) || false;
+                    const value = isProperty[2].trim();
+                    sections[sections.length - 1].lines.push({
+                        property: propertyName,
+                        value: hidden ? value.replace(/./g, '*') : value,
+                        hidden: hidden,
+                        description: (descriptor && descriptor.description) || '',
+                        type: (descriptor && descriptor.type) || '',
+                    });
+                }
+            }
+        });
+
+        return sections;
+    }
+
+    private async createReportsPerNode(presetData: ConfigPreset): Promise<ReportNode[]> {
+        const workingDir = process.cwd();
+        const target = join(workingDir, this.params.target);
+        const descriptions = await BootstrapUtils.loadYaml(join(this.root, 'presets', 'descriptions.yml'));
+        const promises: Promise<ReportNode>[] = (presetData.nodes || []).map(async (n) => {
+            const resourcesFolder = join(target, 'config', n.name, 'resources');
+            const files = await fsPromises.readdir(resourcesFolder);
+            const reportFiles = files
+                .filter((fileName) => fileName.indexOf('.properties') > -1)
+                .map((fileName) => {
+                    const resourceContent = readFileSync(join(resourcesFolder, fileName), 'utf-8');
+                    const sections = this.createReportFromFile(resourceContent, descriptions);
+                    const reportFile: ReportFile = {
+                        fileName: fileName,
+                        sections,
+                    };
+                    return reportFile;
+                });
+            const reportNode: ReportNode = {
+                name: n.name,
+                files: reportFiles,
+            };
+            return reportNode;
+        });
+
+        return Promise.all(promises);
+    }
+
     /**
      *  It generates a .rst config report file per node.
      * @param passedPresetData the preset data,
@@ -23,49 +113,107 @@ export class ReportService {
     public async run(passedPresetData?: ConfigPreset): Promise<string[]> {
         const presetData = passedPresetData ?? BootstrapUtils.loadExistingPresetData(this.params.target);
 
-        const workingDir = process.cwd();
-        const target = join(workingDir, this.params.target);
-        const descriptions = await BootstrapUtils.loadYaml(join(this.root, 'presets', 'descriptions.yml'));
         const reportFolder = join(this.params.target, 'report');
         BootstrapUtils.deleteFolder(reportFolder);
-        const promises = (presetData.nodes || []).map(async (n) => {
-            const resourcesFolder = join(target, 'config', n.name, 'resources');
-            const files = await fsPromises.readdir(resourcesFolder);
+        const reportNodes: ReportNode[] = await this.createReportsPerNode(presetData);
 
-            await BootstrapUtils.mkdir(reportFolder);
-            const reportFile = join(reportFolder, `${n.name}-config.rst`);
+        const missingProperties = _.flatMap(reportNodes, (n) =>
+            _.flatMap(n.files, (f) =>
+                _.flatMap(f.sections, (s) =>
+                    s.lines.filter((s) => !s.type && !s.description && !s.property.startsWith('starting-at-height')).map((s) => s.property),
+                ),
+            ),
+        );
+        const missingDescriptions = _.uniq(missingProperties);
+        if (missingDescriptions.length) {
+            const missingDescriptionsObject = _.mapValues(
+                _.keyBy(missingProperties, (k) => k),
+                () => ({
+                    type: '',
+                    description: '',
+                }),
+            );
+            logger.debug('Missing yaml properties: ' + BootstrapUtils.toYaml(missingDescriptionsObject));
+        }
 
-            const reportContent = files
-                .filter((f) => f.indexOf('.properties') > -1)
-                .map((f) => {
-                    let resourceContent = readFileSync(join(resourcesFolder, f), 'utf-8');
-                    resourceContent = resourceContent.replace(/\[(.*?)\]\n/g, (a, b) => {
-                        return `**${b}**; ; ;\n`;
-                    });
+        // const missingDescriptions = reportNodes.map(node -> node.files)
 
-                    resourceContent = resourceContent.replace(/(.*?) = (.*?)\n/g, (a, b, c) => {
-                        const description = descriptions[b];
-                        return `${b}; ${description?.type || ''} ; ${description?.description || ''} ;${c}\n`;
-                    });
-
-                    resourceContent = resourceContent.replace(/\#.*?\n/g, ``);
-                    resourceContent = resourceContent.replace(/(^[ \t]*\n)/gm, '');
-
-                    return `
-${f}
-${f.replace(/./g, '=')}
-.. csv-table::
-    :header: "Property", "Type", "Description", "Value"
-    :delim: ;
-
-${resourceContent.trim().replace(/^/gm, '    ')}`;
-                })
-                .join('\n');
-
-            await BootstrapUtils.writeTextFile(reportFile, reportContent);
-            logger.info(`Report file ${reportFile} created`);
-            return reportFile;
+        await BootstrapUtils.mkdir(reportFolder);
+        const promises = _.flatMap(reportNodes, (n) => {
+            return [this.toRstReport(reportFolder, n), this.toCsvReport(reportFolder, n)];
         });
         return Promise.all(promises);
+    }
+
+    private async toRstReport(reportFolder: string, n: ReportNode) {
+        const reportFile = join(reportFolder, `${n.name}-config.rst`);
+        const reportContent = n.files
+            .map((fileReport) => {
+                const hasDescriptionSection = fileReport.sections.find((s) => s.lines.find((l) => l.description || l.type));
+                const header = hasDescriptionSection ? '"Property", "Value", "Type", "Description"' : '"Property", "Value"';
+                const csvBody = fileReport.sections
+                    .map((s) => {
+                        const hasDescriptionSection = s.lines.find((l) => l.description || l.type);
+                        return (
+                            (hasDescriptionSection ? `**${s.header}**; ; ;\n` : `**${s.header}**;\n`) +
+                            s.lines
+                                .map((l) => {
+                                    if (hasDescriptionSection)
+                                        return `${l.property}; ${l.value}; ${l.type}; ${l.description}`.trim() + '\n';
+                                    else {
+                                        return `${l.property}; ${l.value}`.trim() + '\n';
+                                    }
+                                })
+                                .join('')
+                        );
+                    })
+                    .join('');
+
+                return `
+${fileReport.fileName}
+${fileReport.fileName.replace(/./g, '=')}
+.. csv-table::
+    :header: ${header}
+    :delim: ;
+
+${csvBody.trim().replace(/^/gm, '    ')}`;
+            })
+            .join('\n');
+
+        await BootstrapUtils.writeTextFile(reportFile, reportContent);
+        logger.info(`Report file ${reportFile} created`);
+        return reportFile;
+    }
+
+    private async toCsvReport(reportFolder: string, n: ReportNode) {
+        const reportFile = join(reportFolder, `${n.name}-config.csv`);
+        const reportContent = n.files
+            .map((fileReport) => {
+                const csvBody = fileReport.sections
+                    .map((s) => {
+                        const hasDescriptionSection = s.lines.find((l) => l.description || l.type);
+                        return (
+                            `${s.header}\n` +
+                            s.lines
+                                .map((l) => {
+                                    if (hasDescriptionSection)
+                                        return `${l.property}; ${l.value}; ${l.type}; ${l.description}`.trim() + '\n';
+                                    else {
+                                        return `${l.property}; ${l.value}`.trim() + '\n';
+                                    }
+                                })
+                                .join('')
+                        );
+                    })
+                    .join('\n');
+
+                return `${fileReport.fileName}
+${csvBody.trim()}`;
+            })
+            .join('\n\n\n');
+
+        await BootstrapUtils.writeTextFile(reportFile, reportContent);
+        logger.info(`Report file ${reportFile} created`);
+        return reportFile;
     }
 }

--- a/src/service/ReportService.ts
+++ b/src/service/ReportService.ts
@@ -1,0 +1,71 @@
+import Logger from '../logger/Logger';
+import LoggerFactory from '../logger/LoggerFactory';
+import { LogType } from '../logger/LogType';
+import { BootstrapUtils } from './BootstrapUtils';
+import { ConfigPreset } from '../model';
+import { join } from 'path';
+import { promises as fsPromises, readFileSync } from 'fs';
+export type ReportParams = { target: string };
+
+const logger: Logger = LoggerFactory.getLogger(LogType.System);
+
+export class ReportService {
+    public static defaultParams: ReportParams = {
+        target: 'target',
+    };
+
+    constructor(private readonly root: string, protected readonly params: ReportParams) {}
+
+    /**
+     *  It generates a .rst config report file per node.
+     * @param passedPresetData the preset data,
+     */
+    public async run(passedPresetData?: ConfigPreset): Promise<string[]> {
+        const presetData = passedPresetData ?? BootstrapUtils.loadExistingPresetData(this.params.target);
+
+        const workingDir = process.cwd();
+        const target = join(workingDir, this.params.target);
+        const descriptions = await BootstrapUtils.loadYaml(join(this.root, 'presets', 'descriptions.yml'));
+        const reportFolder = join(this.params.target, 'report');
+        BootstrapUtils.deleteFolder(reportFolder);
+        const promises = (presetData.nodes || []).map(async (n) => {
+            const resourcesFolder = join(target, 'config', n.name, 'resources');
+            const files = await fsPromises.readdir(resourcesFolder);
+
+            await BootstrapUtils.mkdir(reportFolder);
+            const reportFile = join(reportFolder, `${n.name}-config.rst`);
+
+            const reportContent = files
+                .filter((f) => f.indexOf('.properties') > -1)
+                .map((f) => {
+                    let resourceContent = readFileSync(join(resourcesFolder, f), 'utf-8');
+                    resourceContent = resourceContent.replace(/\[(.*?)\]\n/g, (a, b) => {
+                        return `**${b}**; ; ;\n`;
+                    });
+
+                    resourceContent = resourceContent.replace(/(.*?) = (.*?)\n/g, (a, b, c) => {
+                        const description = descriptions[b];
+                        return `${b}; ${description?.type || ''} ; ${description?.description || ''} ;${c}\n`;
+                    });
+
+                    resourceContent = resourceContent.replace(/\#.*?\n/g, ``);
+                    resourceContent = resourceContent.replace(/(^[ \t]*\n)/gm, '');
+
+                    return `
+${f}
+${f.replace(/./g, '=')}
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+${resourceContent.trim().replace(/^/gm, '    ')}`;
+                })
+                .join('\n');
+
+            await BootstrapUtils.writeTextFile(reportFile, reportContent);
+            logger.info(`Report file ${reportFile} created`);
+            return reportFile;
+        });
+        return Promise.all(promises);
+    }
+}

--- a/test/expected-api-node-config.csv
+++ b/test/expected-api-node-config.csv
@@ -1,0 +1,845 @@
+config-database.properties
+database
+databaseUri; mongodb://db:27017
+databaseName; catapult
+maxWriterThreads; 8
+
+plugins
+catapult.mongo.plugins.accountlink; true
+catapult.mongo.plugins.aggregate; true
+catapult.mongo.plugins.lockhash; true
+catapult.mongo.plugins.locksecret; true
+catapult.mongo.plugins.metadata; true
+catapult.mongo.plugins.mosaic; true
+catapult.mongo.plugins.multisig; true
+catapult.mongo.plugins.namespace; true
+catapult.mongo.plugins.restrictionaccount; true
+catapult.mongo.plugins.restrictionmosaic; true
+catapult.mongo.plugins.transfer; true
+
+
+config-extensions-broker.properties
+extensions
+extension.addressextraction; true
+extension.mongo; true
+extension.zeromq; true
+extension.hashcache; true
+
+
+config-extensions-recovery.properties
+extensions
+extension.addressextraction; true
+extension.mongo; true
+extension.zeromq; true
+extension.hashcache; true
+
+
+config-extensions-server.properties
+extensions
+extension.filespooling; true
+extension.partialtransaction; true
+extension.addressextraction; false
+extension.mongo; false
+extension.zeromq; false
+extension.eventsource; false
+extension.harvesting; true
+extension.syncsource; true
+extension.diagnostics; true
+extension.finalization; true
+extension.hashcache; true
+extension.networkheight; false
+extension.nodediscovery; true
+extension.packetserver; true
+extension.pluginhandlers; true
+extension.sync; true
+extension.timesync; true
+extension.transactionsink; true
+extension.unbondedpruning; true
+
+
+config-finalization.properties
+finalization
+enableVoting; true
+size; 10'000
+threshold; 7'000
+stepDuration; 4m
+shortLivedCacheMessageDuration; 10m
+messageSynchronizationMaxResponseSize; 20MB
+maxHashesPerPoint; 256
+prevoteBlocksMultiple; 4
+votingKeyDilution; 128
+
+
+config-harvesting.properties
+harvesting
+harvesterSigningPrivateKey; ****************************************************************; string; Harvester signing private key.
+harvesterVrfPrivateKey; ****************************************************************; string; Harvester vrf private key.
+enableAutoHarvesting; true; bool; Set to true if auto harvesting is enabled.
+maxUnlockedAccounts; 5; uint32_t; Maximum number of unlocked accounts.
+delegatePrioritizationPolicy; Importance; harvesting::DelegatePrioritizationPolicy; Delegate harvester prioritization policy.
+beneficiaryAddress; ; Address; Address of the account receiving part of the harvested fee.
+
+
+config-inflation.properties
+inflation
+starting-at-height-2; 95998521
+starting-at-height-200; 91882261
+starting-at-height-400; 87942499
+starting-at-height-600; 84171668
+starting-at-height-800; 80562525
+starting-at-height-2537757; 77108135
+starting-at-height-3062757; 73801864
+starting-at-height-3587757; 70637360
+starting-at-height-4112757; 67608545
+starting-at-height-4637757; 64709601
+starting-at-height-5162757; 61934959
+starting-at-height-5687757; 59279289
+starting-at-height-6212757; 56737489
+starting-at-height-6737757; 54304678
+starting-at-height-7262757; 51976182
+starting-at-height-7787757; 49747528
+starting-at-height-8312757; 47614435
+starting-at-height-8837757; 45572806
+starting-at-height-9362757; 43618718
+starting-at-height-9887757; 41748419
+starting-at-height-10412757; 39958315
+starting-at-height-10937757; 38244967
+starting-at-height-11462757; 36605085
+starting-at-height-11987757; 35035519
+starting-at-height-12512757; 33533253
+starting-at-height-13037757; 32095402
+starting-at-height-13562757; 30719203
+starting-at-height-14087757; 29402014
+starting-at-height-14612757; 28141304
+starting-at-height-15137757; 26934650
+starting-at-height-15662757; 25779736
+starting-at-height-16187757; 24674343
+starting-at-height-16712757; 23616348
+starting-at-height-17237757; 22603717
+starting-at-height-17762757; 21634507
+starting-at-height-18287757; 20706854
+starting-at-height-18812757; 19818978
+starting-at-height-19337757; 18969173
+starting-at-height-19862757; 18155805
+starting-at-height-20387757; 17377314
+starting-at-height-20912757; 16632203
+starting-at-height-21437757; 15919041
+starting-at-height-21962757; 15236459
+starting-at-height-22487757; 14583144
+starting-at-height-23012757; 13957843
+starting-at-height-23537757; 13359353
+starting-at-height-24062757; 12786526
+starting-at-height-24587757; 12238261
+starting-at-height-25112757; 11713504
+starting-at-height-25637757; 11211248
+starting-at-height-26162757; 10730528
+starting-at-height-26687757; 10270420
+starting-at-height-27212757; 9830041
+starting-at-height-27737757; 9408545
+starting-at-height-28262757; 9005122
+starting-at-height-28787757; 8618997
+starting-at-height-29312757; 8249428
+starting-at-height-29837757; 7895707
+starting-at-height-30362757; 7557151
+starting-at-height-30887757; 7233113
+starting-at-height-31412757; 6922969
+starting-at-height-31937757; 6626123
+starting-at-height-32462757; 6342006
+starting-at-height-32987757; 6070071
+starting-at-height-33512757; 5809796
+starting-at-height-34037757; 5560682
+starting-at-height-34562757; 5322249
+starting-at-height-35087757; 5094039
+starting-at-height-35612757; 4875615
+starting-at-height-36137757; 4666557
+starting-at-height-36662757; 4466462
+starting-at-height-37187757; 4274948
+starting-at-height-37712757; 4091645
+starting-at-height-38237757; 3916202
+starting-at-height-38762757; 3748282
+starting-at-height-39287757; 3587561
+starting-at-height-39812757; 3433732
+starting-at-height-40337757; 3286500
+starting-at-height-40862757; 3145580
+starting-at-height-41387757; 3010703
+starting-at-height-41912757; 2881608
+starting-at-height-42437757; 2758050
+starting-at-height-42962757; 2639789
+starting-at-height-43487757; 2526599
+starting-at-height-44012757; 2418263
+starting-at-height-44537757; 2314572
+starting-at-height-45062757; 2215326
+starting-at-height-45587757; 2120337
+starting-at-height-46112757; 2029420
+starting-at-height-46637757; 1942402
+starting-at-height-47162757; 1859115
+starting-at-height-47687757; 1779399
+starting-at-height-48212757; 1703101
+starting-at-height-48737757; 1630075
+starting-at-height-49262757; 1560180
+starting-at-height-49787757; 1493282
+starting-at-height-50312757; 1429253
+starting-at-height-50837757; 1367969
+starting-at-height-51362757; 1309312
+starting-at-height-51887757; 1253171
+starting-at-height-52412757; 1199437
+starting-at-height-52937757; 1148007
+starting-at-height-53462757; 1098783
+starting-at-height-53987757; 1051669
+starting-at-height-54512757; 1006575
+starting-at-height-55037757; 963414
+starting-at-height-55562757; 922105
+starting-at-height-56087757; 882566
+starting-at-height-56612757; 844723
+starting-at-height-57137757; 808503
+starting-at-height-57662757; 773836
+starting-at-height-58187757; 740655
+starting-at-height-58712757; 708897
+starting-at-height-59237757; 678500
+starting-at-height-59762757; 649407
+starting-at-height-60287757; 621562
+starting-at-height-60812757; 594910
+starting-at-height-61337757; 569401
+starting-at-height-61862757; 544986
+starting-at-height-62387757; 521618
+starting-at-height-62912757; 499252
+starting-at-height-63437757; 477845
+starting-at-height-63962757; 457356
+starting-at-height-64487757; 437745
+starting-at-height-65012757; 418975
+starting-at-height-65537757; 401010
+starting-at-height-66062757; 383816
+starting-at-height-66587757; 367358
+starting-at-height-67112757; 351606
+starting-at-height-67637757; 336530
+starting-at-height-68162757; 322100
+starting-at-height-68687757; 308289
+starting-at-height-69212757; 295070
+starting-at-height-69737757; 282418
+starting-at-height-70262757; 270308
+starting-at-height-70787757; 258718
+starting-at-height-71312757; 247624
+starting-at-height-71837757; 237007
+starting-at-height-72362757; 226844
+starting-at-height-72887757; 217118
+starting-at-height-73412757; 207808
+starting-at-height-73937757; 198897
+starting-at-height-74462757; 190369
+starting-at-height-74987757; 182206
+starting-at-height-75512757; 174394
+starting-at-height-76037757; 166916
+starting-at-height-76562757; 159759
+starting-at-height-77087757; 152908
+starting-at-height-77612757; 146352
+starting-at-height-78137757; 140077
+starting-at-height-78662757; 134070
+starting-at-height-79187757; 128322
+starting-at-height-79712757; 122819
+starting-at-height-80237757; 117553
+starting-at-height-80762757; 112513
+starting-at-height-81287757; 107688
+starting-at-height-81812757; 103071
+starting-at-height-82337757; 98651
+starting-at-height-82862757; 94421
+starting-at-height-83387757; 90372
+starting-at-height-83912757; 86497
+starting-at-height-84437757; 82789
+starting-at-height-84962757; 79239
+starting-at-height-85487757; 75841
+starting-at-height-86012757; 72589
+starting-at-height-86537757; 69477
+starting-at-height-87062757; 66498
+starting-at-height-87587757; 63646
+starting-at-height-88112757; 60917
+starting-at-height-88637757; 58305
+starting-at-height-89162757; 55805
+starting-at-height-89687757; 53412
+starting-at-height-90212757; 51122
+starting-at-height-90737757; 48930
+starting-at-height-91262757; 46832
+starting-at-height-91787757; 44824
+starting-at-height-92312757; 42902
+starting-at-height-92837757; 41062
+starting-at-height-93362757; 39301
+starting-at-height-93887757; 37616
+starting-at-height-94412757; 36003
+starting-at-height-94937757; 34460
+starting-at-height-95462757; 32982
+starting-at-height-95987757; 31568
+starting-at-height-96512757; 30214
+starting-at-height-97037757; 28919
+starting-at-height-97562757; 27679
+starting-at-height-98087757; 26492
+starting-at-height-98612757; 25356
+starting-at-height-99137757; 24269
+starting-at-height-99662757; 23228
+starting-at-height-100187757; 22232
+starting-at-height-100712757; 21279
+starting-at-height-101237757; 20366
+starting-at-height-101762757; 19493
+starting-at-height-102287757; 18657
+starting-at-height-102812757; 17857
+starting-at-height-103337757; 17091
+starting-at-height-103862757; 16358
+starting-at-height-104387757; 15657
+starting-at-height-104912757; 14986
+starting-at-height-105437757; 14343
+starting-at-height-105962757; 13728
+starting-at-height-106487757; 13139
+starting-at-height-107012757; 12576
+starting-at-height-107537757; 12037
+starting-at-height-108062757; 11521
+starting-at-height-108587757; 11027
+starting-at-height-109112757; 10554
+starting-at-height-109637757; 10101
+starting-at-height-110162757; 9668
+starting-at-height-110687757; 9254
+starting-at-height-111212757; 8857
+starting-at-height-111737757; 8477
+starting-at-height-112262757; 8113
+starting-at-height-112787757; 7766
+starting-at-height-113312757; 7433
+starting-at-height-113837757; 7114
+starting-at-height-114362757; 6809
+starting-at-height-114887757; 6517
+starting-at-height-115412757; 6237
+starting-at-height-115937757; 5970
+starting-at-height-116462757; 5714
+starting-at-height-116987757; 5469
+starting-at-height-117512757; 5234
+starting-at-height-118037757; 5010
+starting-at-height-118562757; 4795
+starting-at-height-119087757; 4589
+starting-at-height-119612757; 4393
+starting-at-height-120137757; 4204
+starting-at-height-120662757; 4024
+starting-at-height-121187757; 3851
+starting-at-height-121712757; 3686
+starting-at-height-122237757; 3528
+starting-at-height-122762757; 3377
+starting-at-height-123287757; 3232
+starting-at-height-123812757; 3093
+starting-at-height-124337757; 2961
+starting-at-height-124862757; 2834
+starting-at-height-125387757; 2712
+starting-at-height-125912757; 2596
+starting-at-height-126437757; 2485
+starting-at-height-126962757; 2378
+starting-at-height-127487757; 2276
+starting-at-height-128012757; 2178
+starting-at-height-128537757; 2085
+starting-at-height-129062757; 1996
+starting-at-height-129587757; 1910
+starting-at-height-130112757; 1828
+starting-at-height-130637757; 1750
+starting-at-height-131162757; 1675
+starting-at-height-131687757; 1603
+starting-at-height-132212757; 1534
+starting-at-height-132737757; 1468
+starting-at-height-133262757; 1405
+starting-at-height-133787757; 1345
+starting-at-height-134312757; 1287
+starting-at-height-134837757; 1232
+starting-at-height-135362757; 1179
+starting-at-height-135887757; 1129
+starting-at-height-136412757; 1080
+starting-at-height-136937757; 1034
+starting-at-height-137462757; 990
+starting-at-height-137987757; 947
+starting-at-height-138512757; 907
+starting-at-height-139037757; 868
+starting-at-height-139562757; 830
+starting-at-height-140087757; 795
+starting-at-height-140612757; 761
+starting-at-height-141137757; 728
+starting-at-height-141662757; 697
+starting-at-height-142187757; 667
+starting-at-height-142712757; 638
+starting-at-height-143237757; 611
+starting-at-height-143762757; 585
+starting-at-height-144287757; 560
+starting-at-height-144812757; 536
+starting-at-height-145337757; 513
+starting-at-height-145862757; 491
+starting-at-height-146387757; 470
+starting-at-height-146912757; 449
+starting-at-height-147437757; 430
+starting-at-height-147962757; 412
+starting-at-height-148487757; 394
+starting-at-height-149012757; 377
+starting-at-height-149537757; 361
+starting-at-height-150062757; 345
+starting-at-height-150587757; 331
+starting-at-height-151112757; 316
+starting-at-height-151637757; 303
+starting-at-height-152162757; 290
+starting-at-height-152687757; 277
+starting-at-height-153212757; 265
+starting-at-height-153737757; 254
+starting-at-height-154262757; 243
+starting-at-height-154787757; 233
+starting-at-height-155312757; 223
+starting-at-height-155837757; 213
+starting-at-height-156362757; 204
+starting-at-height-156887757; 195
+starting-at-height-157412757; 187
+starting-at-height-157937757; 179
+starting-at-height-158462757; 171
+starting-at-height-158987757; 164
+starting-at-height-159512757; 157
+starting-at-height-160037757; 150
+starting-at-height-160562757; 143
+starting-at-height-161087757; 137
+starting-at-height-161612757; 131
+starting-at-height-162137757; 126
+starting-at-height-162662757; 120
+starting-at-height-163187757; 115
+starting-at-height-163712757; 110
+starting-at-height-164237757; 105
+starting-at-height-164762757; 101
+starting-at-height-165287757; 97
+starting-at-height-165812757; 92
+starting-at-height-166337757; 88
+starting-at-height-166862757; 85
+starting-at-height-167387757; 81
+starting-at-height-167912757; 77
+starting-at-height-168437757; 74
+starting-at-height-168962757; 71
+starting-at-height-169487757; 68
+starting-at-height-170012757; 65
+starting-at-height-170537757; 62
+starting-at-height-171062757; 59
+starting-at-height-171587757; 57
+starting-at-height-172112757; 54
+starting-at-height-172637757; 52
+starting-at-height-173162757; 50
+starting-at-height-173687757; 48
+starting-at-height-174212757; 46
+starting-at-height-174737757; 44
+starting-at-height-175262757; 42
+starting-at-height-175787757; 40
+starting-at-height-176312757; 38
+starting-at-height-176837757; 37
+starting-at-height-177362757; 35
+starting-at-height-177887757; 33
+starting-at-height-178412757; 32
+starting-at-height-178937757; 31
+starting-at-height-179462757; 29
+starting-at-height-179987757; 28
+starting-at-height-180512757; 27
+starting-at-height-181037757; 26
+starting-at-height-181562757; 24
+starting-at-height-182087757; 23
+starting-at-height-182612757; 22
+starting-at-height-183137757; 21
+starting-at-height-183662757; 20
+starting-at-height-184187757; 20
+starting-at-height-184712757; 19
+starting-at-height-185237757; 18
+starting-at-height-185762757; 17
+starting-at-height-186287757; 16
+starting-at-height-186812757; 16
+starting-at-height-187337757; 15
+starting-at-height-187862757; 14
+starting-at-height-188387757; 14
+starting-at-height-188912757; 13
+starting-at-height-189437757; 12
+starting-at-height-189962757; 12
+starting-at-height-190487757; 11
+starting-at-height-191012757; 11
+starting-at-height-191537757; 10
+starting-at-height-192062757; 10
+starting-at-height-192587757; 9
+starting-at-height-193112757; 9
+starting-at-height-193637757; 9
+starting-at-height-194162757; 8
+starting-at-height-194687757; 8
+starting-at-height-195212757; 8
+starting-at-height-195737757; 7
+starting-at-height-196262757; 7
+starting-at-height-196787757; 7
+starting-at-height-197312757; 6
+starting-at-height-197837757; 6
+starting-at-height-198362757; 6
+starting-at-height-198887757; 5
+starting-at-height-199412757; 5
+starting-at-height-199937757; 5
+starting-at-height-200462757; 5
+starting-at-height-200987757; 4
+starting-at-height-201512757; 4
+starting-at-height-202037757; 4
+starting-at-height-202562757; 4
+starting-at-height-203087757; 4
+starting-at-height-203612757; 4
+starting-at-height-204137757; 3
+starting-at-height-204662757; 3
+starting-at-height-205187757; 3
+starting-at-height-205712757; 3
+starting-at-height-206237757; 3
+starting-at-height-206762757; 3
+starting-at-height-207287757; 2
+starting-at-height-207812757; 2
+starting-at-height-208337757; 2
+starting-at-height-208862757; 2
+starting-at-height-209387757; 2
+starting-at-height-209912757; 2
+starting-at-height-210437757; 2
+starting-at-height-210962757; 2
+starting-at-height-211487757; 2
+starting-at-height-212012757; 2
+starting-at-height-212537757; 1
+starting-at-height-213062757; 1
+starting-at-height-213587757; 1
+starting-at-height-214112757; 1
+starting-at-height-214637757; 1
+starting-at-height-215162757; 1
+starting-at-height-215687757; 1
+starting-at-height-216212757; 1
+starting-at-height-216737757; 1
+starting-at-height-217262757; 1
+starting-at-height-217787757; 1
+starting-at-height-218312757; 1
+starting-at-height-218837757; 1
+starting-at-height-219362757; 1
+starting-at-height-219887757; 1
+starting-at-height-220412757; 1
+starting-at-height-220937757; 0
+
+
+config-logging-broker.properties
+console
+sinkType; Async
+level; Info
+colorMode; Ansi
+
+console.component.levels
+
+file
+sinkType; Async
+level; Info
+directory; logs
+filePattern; logs/catapult_broker%4N.log
+rotationSize; 25MB
+maxTotalSize; 2500MB
+minFreeSpace; 100MB
+
+file.component.levels
+
+
+config-logging-recovery.properties
+console
+sinkType; Async
+level; Info
+colorMode; Ansi
+
+console.component.levels
+
+file
+sinkType; Async
+level; Info
+directory; logs
+filePattern; logs/catapult_recovery%4N.log
+rotationSize; 25MB
+maxTotalSize; 2500MB
+minFreeSpace; 100MB
+
+file.component.levels
+
+
+config-logging-server.properties
+console
+sinkType; Async
+level; Info
+colorMode; Ansi
+
+console.component.levels
+
+file
+sinkType; Async
+level; Info
+directory; logs
+filePattern; logs/catapult_server%4N.log
+rotationSize; 25MB
+maxTotalSize; 2500MB
+minFreeSpace; 100MB
+
+file.component.levels
+
+
+config-messaging.properties
+messaging
+subscriberPort; 7902
+
+
+config-network.properties
+network
+identifier; public-test; NetworkIdentifier; Network identifier.
+nemesisSignerPublicKey; 78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0; Key; Nemesis public key.
+nodeEqualityStrategy; host; NodeIdentityEqualityStrategy; Node equality strategy.
+generationHashSeed; 6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD; ;
+epochAdjustment; 1573430400s; utils::TimeSpan; Nemesis epoch time adjustment.
+
+chain
+enableVerifiableState; true; bool; Set to true if block chain should calculate state hashes so that state is fully verifiable at each block.
+enableVerifiableReceipts; true; bool; Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block.
+currencyMosaicId; 0x5B66'E76B'ECAD'0860; MosaicId; Mosaic id used as primary chain currency.
+harvestingMosaicId; 0x5B66'E76B'ECAD'0860; MosaicId; Mosaic id used to provide harvesting ability.
+blockGenerationTargetTime; 30s; utils::TimeSpan; Targeted time between blocks.
+blockTimeSmoothingFactor; 3000; uint32_t; Note: A higher value makes the network more biased. Note: This can lower security because it will increase the influence of time relative to importance.
+importanceGrouping; 180; uint64_t; Number of blocks that should be treated as a group for importance purposes. Note: Importances will only be calculated at blocks that are multiples of this grouping number.
+importanceActivityPercentage; 5; uint8_t; Percentage of importance resulting from fee generation and beneficiary usage.
+maxRollbackBlocks; 0; uint32_t; Maximum number of blocks that can be rolled back.
+maxDifficultyBlocks; 60; uint32_t; Maximum number of blocks to use in a difficulty calculation.
+defaultDynamicFeeMultiplier; 1'000; BlockFeeMultiplier; Default multiplier to use for dynamic fees.
+maxTransactionLifetime; 6h; utils::TimeSpan; Maximum lifetime a transaction can have before it expires.
+maxBlockFutureTime; 500ms; utils::TimeSpan; Maximum future time of a block that can be accepted.
+initialCurrencyAtomicUnits; 7'831'975'436'000'000; Amount; Initial currency atomic units available in the network.
+maxMosaicAtomicUnits; 9'000'000'000'000'000; Amount; Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network.
+totalChainImportance; 7'831'975'436'000'000; Importance; Total whole importance units available in the network.
+minHarvesterBalance; 10'000'000'000; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+maxHarvesterBalance; 50'000'000'000'000; Amount; Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+minVoterBalance; 3'000'000'000'000; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting.
+votingSetGrouping; 720; ;
+maxVotingKeysPerAccount; 3; uint8_t; Maximum number of voting keys that can be registered at once per account.
+minVotingKeyLifetime; 28; uint32_t; Minimum number of finalization rounds for which voting key can be registered.
+maxVotingKeyLifetime; 26280; uint32_t; Maximum number of finalization rounds for which voting key can be registered.
+harvestBeneficiaryPercentage; 25; uint8_t; Percentage of the harvested fee that is collected by the beneficiary account.
+harvestNetworkPercentage; 5; uint8_t; Percentage of the harvested fee that is collected by the network.
+harvestNetworkFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the harvest network fee sink account.
+maxTransactionsPerBlock; 6'000; uint32_t; Maximum number of transactions per block.
+
+plugin:catapult.plugins.accountlink
+dummy; to trigger plugin load
+
+plugin:catapult.plugins.aggregate
+maxTransactionsPerAggregate; 100; uint32_t; Maximum number of transactions per aggregate.
+maxCosignaturesPerAggregate; 25; uint8_t; Maximum number of cosignatures per aggregate.
+enableStrictCosignatureCheck; false; bool; Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally.
+enableBondedAggregateSupport; true; bool; Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected.
+maxBondedTransactionLifetime; 48h; utils::TimeSpan; Maximum lifetime a bonded transaction can have before it expires.
+
+plugin:catapult.plugins.lockhash
+lockedFundsPerAggregate; 10'000'000; Amount; Amount that has to be locked per aggregate in partial cache.
+maxHashLockDuration; 2d; utils::BlockSpan; Maximum number of blocks for which a hash lock can exist.
+
+plugin:catapult.plugins.locksecret
+maxSecretLockDuration; 365d; utils::BlockSpan; Maximum number of blocks for which a secret lock can exist.
+minProofSize; 20; uint16_t; Minimum size of a proof in bytes.
+maxProofSize; 1024; uint16_t; Maximum size of a proof in bytes.
+
+plugin:catapult.plugins.metadata
+maxValueSize; 1024; uint16_t; Maximum metadata value size.
+
+plugin:catapult.plugins.mosaic
+maxMosaicsPerAccount; 1'000; uint16_t; Maximum number of mosaics that an account can own.
+maxMosaicDuration; 3650d; utils::BlockSpan; Maximum mosaic duration.
+maxMosaicDivisibility; 6; uint8_t; Maximum mosaic divisibility.
+mosaicRentalFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the mosaic rental fee sink account.
+mosaicRentalFee; 500; Amount; Mosaic rental fee.
+
+plugin:catapult.plugins.multisig
+maxMultisigDepth; 3; uint8_t; Maximum number of multisig levels.
+maxCosignatoriesPerAccount; 25; uint32_t; Maximum number of cosignatories per account.
+maxCosignedAccountsPerAccount; 25; uint32_t; Maximum number of accounts a single account can cosign.
+
+plugin:catapult.plugins.namespace
+maxNameSize; 64; uint8_t; Maximum namespace name size.
+maxChildNamespaces; 256; uint16_t; Maximum number of children for a root namespace.
+maxNamespaceDepth; 3; uint8_t; Maximum namespace depth.
+minNamespaceDuration; 30d; utils::BlockSpan; Minimum namespace duration.
+maxNamespaceDuration; 1825d; utils::BlockSpan; Maximum namespace duration.
+namespaceGracePeriodDuration; 1d; utils::BlockSpan; Grace period during which time only the previous owner can renew an expired namespace.
+reservedRootNamespaceNames; symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info; unordered_set<string>; Reserved root namespaces that cannot be claimed.
+namespaceRentalFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the namespace rental fee sink account.
+rootNamespaceRentalFeePerBlock; 1; Amount; Root namespace rental fee per block.
+childNamespaceRentalFee; 100; Amount; Child namespace rental fee.
+
+plugin:catapult.plugins.restrictionaccount
+maxAccountRestrictionValues; 512; uint16_t; Maximum number of account restriction values.
+
+plugin:catapult.plugins.restrictionmosaic
+maxMosaicRestrictionValues; 20; uint8_t; Maximum number of mosaic restriction values.
+
+plugin:catapult.plugins.transfer
+maxMessageSize; 1024; uint16_t; Maximum transaction message size.
+
+
+config-networkheight.properties
+networkheight
+maxNodes; 5
+
+
+config-node.properties
+node
+port; 7900; unsigned short; Server port.
+maxIncomingConnectionsPerIdentity; 6; uint32_t; Maximum number of incoming connections per identity over primary port.
+enableAddressReuse; false; bool; Set to true if the server should reuse ports already in use.
+enableSingleThreadPool; false; bool; Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used.
+enableCacheDatabaseStorage; true; bool; Set to true if cache data should be saved in a database.
+enableAutoSyncCleanup; false; bool; Set to true if temporary sync files should be automatically cleaned up. Note: This should be Set to false if broker process is running.
+enableTransactionSpamThrottling; true; bool; Set to true if transaction spam throttling should be enabled.
+transactionSpamThrottlingMaxBoostFee; 10'000'000; Amount; Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled.
+maxHashesPerSyncAttempt; 610; ;
+maxBlocksPerSyncAttempt; 602; uint32_t; Maximum number of blocks per sync attempt.
+maxChainBytesPerSyncAttempt; 100MB; utils::FileSize; Maximum chain bytes per sync attempt.
+shortLivedCacheTransactionDuration; 10m; utils::TimeSpan; Duration of a transaction in the short lived cache.
+shortLivedCacheBlockDuration; 100m; utils::TimeSpan; Duration of a block in the short lived cache.
+shortLivedCachePruneInterval; 90s; utils::TimeSpan; Time between short lived cache pruning.
+shortLivedCacheMaxSize; 200'000; uint32_t; Maximum size of a short lived cache.
+minFeeMultiplier; 100; BlockFeeMultiplier; Minimum fee multiplier of transactions to propagate and include in blocks.
+transactionSelectionStrategy; maximize-fee; model::TransactionSelectionStrategy; Transaction selection strategy used for syncing and harvesting unconfirmed transactions.
+unconfirmedTransactionsCacheMaxResponseSize; 20MB; utils::FileSize; Maximum size of an unconfirmed transactions response.
+unconfirmedTransactionsCacheMaxSize; 50'000; uint32_t; Maximum size of the unconfirmed transactions cache.
+connectTimeout; 15s; utils::TimeSpan; Timeout for connecting to a peer.
+syncTimeout; 120s; utils::TimeSpan; Timeout for syncing with a peer.
+socketWorkingBufferSize; 512KB; utils::FileSize; Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size).
+socketWorkingBufferSensitivity; 100; uint32_t; Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). Note: Set to 0 will disable memory reclamation.
+maxPacketDataSize; 150MB; utils::FileSize; Maximum packet data size.
+blockDisruptorSize; 4096; uint32_t; Size of the block disruptor circular buffer.
+blockElementTraceInterval; 1; uint32_t; Multiple of elements at which a block element should be traced through queue and completion.
+transactionDisruptorSize; 16384; uint32_t; Size of the transaction disruptor circular buffer.
+transactionElementTraceInterval; 10; uint32_t; Multiple of elements at which a transaction element should be traced through queue and completion.
+enableDispatcherAbortWhenFull; false; bool; Set to true if the process should terminate when any dispatcher is full.
+enableDispatcherInputAuditing; false; bool; Set to true if all dispatcher inputs should be audited.
+maxCacheDatabaseWriteBatchSize; 5MB; utils::FileSize; Maximum cache database write batch size.
+maxTrackedNodes; 5'000; uint32_t; Maximum number of nodes to track in memory.
+trustedHosts; ; unordered_set<string>; Trusted hosts that are allowed to execute protected API calls on this node.
+localNetworks; 127.0.0.1, 172.20.0.25; unordered_set<string>; Networks that should be treated as local.
+
+localnode
+host; ; string; Node host (leave empty to auto-detect IP).
+friendlyName; myFriendlyName; string; Node friendly name (leave empty to use address).
+version; 0; uint32_t; Node version.
+roles; Api,Peer,Voting; ionet::NodeRoles; Node roles.
+
+outgoing_connections
+maxConnections; 10; uint16_t; Maximum number of active connections.
+maxConnectionAge; 200; uint16_t; Maximum connection age.
+maxConnectionBanAge; 20; uint16_t; Maximum connection ban age.
+numConsecutiveFailuresBeforeBanning; 3; uint16_t; Number of consecutive connection failures before a connection is banned.
+
+incoming_connections
+maxConnections; 512; uint16_t; Maximum number of active connections.
+maxConnectionAge; 200; uint16_t; Maximum connection age.
+maxConnectionBanAge; 20; uint16_t; Maximum connection ban age.
+numConsecutiveFailuresBeforeBanning; 3; uint16_t; Number of consecutive connection failures before a connection is banned.
+backlogSize; 512; uint16_t; Maximum size of the pending connections queue.
+
+banning
+defaultBanDuration; 12h; utils::TimeSpan; Default duration for banning.
+maxBanDuration; 12h; utils::TimeSpan; Maximum duration for banning.
+keepAliveDuration; 48h; utils::TimeSpan; Duration to keep account in container after the ban expired.
+maxBannedNodes; 5'000; uint32_t; Maximum number of banned nodes.
+numReadRateMonitoringBuckets; 4; uint16_t; Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring).
+readRateMonitoringBucketDuration; 15s; utils::TimeSpan; Duration of each read rate monitoring bucket.
+maxReadRateMonitoringTotalSize; 100MB; utils::FileSize; Maximum size allowed during full read rate monitoring period.
+
+
+config-pt.properties
+partialtransactions
+cacheMaxResponseSize; 20MB
+cacheMaxSize; 1'000'000
+
+
+config-task.properties
+logging task
+startDelay; 1m
+repeatDelay; 10m
+
+connect peers task for service Finalization
+startDelay; 2s
+repeatDelay; 1m
+
+finalization task
+startDelay; 2m
+repeatDelay; 15s
+
+pull finalization messages task
+startDelay; 3s
+repeatDelay; 1s
+
+pull finalization proof task
+startDelay; 10s
+repeatDelay; 50s
+
+harvesting task
+startDelay; 30s
+repeatDelay; 1s
+
+network chain height detection
+startDelay; 1s
+repeatDelay; 15s
+
+node discovery peers task
+startDelay; 1m
+minDelay; 1m
+maxDelay; 10m
+numPhaseOneRounds; 10
+numTransitionRounds; 20
+
+node discovery ping task
+startDelay; 2m
+repeatDelay; 5m
+
+age peers task for service Readers
+startDelay; 1m
+repeatDelay; 1m
+
+batch partial transaction task
+startDelay; 500ms
+repeatDelay; 500ms
+
+connect peers task for service Pt
+startDelay; 3s
+repeatDelay; 1m
+
+pull partial transactions task
+startDelay; 10s
+repeatDelay; 3s
+
+batch transaction task
+startDelay; 500ms
+repeatDelay; 500ms
+
+connect peers task for service Sync
+startDelay; 1s
+repeatDelay; 1m
+
+pull unconfirmed transactions task
+startDelay; 4s
+repeatDelay; 3s
+
+synchronizer task
+startDelay; 3s
+repeatDelay; 3s
+
+time synchronization task
+startDelay; 1m
+minDelay; 3m
+maxDelay; 180m
+numPhaseOneRounds; 5
+numTransitionRounds; 10
+
+static node refresh task
+startDelay; 5ms
+minDelay; 15s
+maxDelay; 24h
+numPhaseOneRounds; 20
+numTransitionRounds; 20
+
+
+config-timesync.properties
+timesynchronization
+maxNodes; 20
+minImportance; 3'750
+
+
+config-user.properties
+account
+enableDelegatedHarvestersAutoDetection; true
+
+storage
+certificateDirectory; /userconfig/resources/cert
+dataDirectory; /data
+pluginsDirectory; /usr/catapult/lib
+votingKeysDirectory; /data/votingkeys

--- a/test/expected-api-node-config.rst
+++ b/test/expected-api-node-config.rst
@@ -1,0 +1,874 @@
+
+config-database.properties
+==========================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **database**; ; ;
+    databaseUri;  ;  ;mongodb://db:27017
+    databaseName;  ;  ;catapult
+    maxWriterThreads;  ;  ;8
+    **plugins**; ; ;
+    catapult.mongo.plugins.accountlink;  ;  ;true
+    catapult.mongo.plugins.aggregate;  ;  ;true
+    catapult.mongo.plugins.lockhash;  ;  ;true
+    catapult.mongo.plugins.locksecret;  ;  ;true
+    catapult.mongo.plugins.metadata;  ;  ;true
+    catapult.mongo.plugins.mosaic;  ;  ;true
+    catapult.mongo.plugins.multisig;  ;  ;true
+    catapult.mongo.plugins.namespace;  ;  ;true
+    catapult.mongo.plugins.restrictionaccount;  ;  ;true
+    catapult.mongo.plugins.restrictionmosaic;  ;  ;true
+    catapult.mongo.plugins.transfer;  ;  ;true
+
+config-extensions-broker.properties
+===================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **extensions**; ; ;
+    extension.addressextraction;  ;  ;true
+    extension.mongo;  ;  ;true
+    extension.zeromq;  ;  ;true
+    extension.hashcache;  ;  ;true
+
+config-extensions-recovery.properties
+=====================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **extensions**; ; ;
+    extension.addressextraction;  ;  ;true
+    extension.mongo;  ;  ;true
+    extension.zeromq;  ;  ;true
+    extension.hashcache;  ;  ;true
+
+config-extensions-server.properties
+===================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **extensions**; ; ;
+    extension.filespooling;  ;  ;true
+    extension.partialtransaction;  ;  ;true
+    extension.addressextraction;  ;  ;false
+    extension.mongo;  ;  ;false
+    extension.zeromq;  ;  ;false
+    extension.eventsource;  ;  ;false
+    extension.harvesting;  ;  ;true
+    extension.syncsource;  ;  ;true
+    extension.diagnostics;  ;  ;true
+    extension.finalization;  ;  ;true
+    extension.hashcache;  ;  ;true
+    extension.networkheight;  ;  ;false
+    extension.nodediscovery;  ;  ;true
+    extension.packetserver;  ;  ;true
+    extension.pluginhandlers;  ;  ;true
+    extension.sync;  ;  ;true
+    extension.timesync;  ;  ;true
+    extension.transactionsink;  ;  ;true
+    extension.unbondedpruning;  ;  ;true
+
+config-finalization.properties
+==============================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **finalization**; ; ;
+    enableVoting;  ;  ;true
+    size;  ;  ;10'000
+    threshold;  ;  ;7'000
+    stepDuration;  ;  ;4m
+    shortLivedCacheMessageDuration;  ;  ;10m
+    messageSynchronizationMaxResponseSize;  ;  ;20MB
+    maxHashesPerPoint;  ;  ;256
+    prevoteBlocksMultiple;  ;  ;4
+    votingKeyDilution;  ;  ;128
+
+config-harvesting.properties
+============================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **harvesting**; ; ;
+    harvesterSigningPrivateKey; string ; Harvester signing private key. ;19CBD6AE842F9FDDC8F6F2AE8081981CF2268435BACA6A8A6A91740D631494BD
+    harvesterVrfPrivateKey; string ; Harvester vrf private key. ;620857FB100B5F34379DAD160C9A43D6B1BDC562D83DC37A468DD99D31C830F6
+    enableAutoHarvesting; bool ; Set to true if auto harvesting is enabled. ;true
+    maxUnlockedAccounts; uint32_t ; Maximum number of unlocked accounts. ;5
+    delegatePrioritizationPolicy; harvesting::DelegatePrioritizationPolicy ; Delegate harvester prioritization policy. ;Importance
+    beneficiaryAddress; Address ; Address of the account receiving part of the harvested fee. ;
+
+config-inflation.properties
+===========================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **inflation**; ; ;
+    starting-at-height-2;  ;  ;95998521
+    starting-at-height-200;  ;  ;91882261
+    starting-at-height-400;  ;  ;87942499
+    starting-at-height-600;  ;  ;84171668
+    starting-at-height-800;  ;  ;80562525
+    starting-at-height-2537757;  ;  ;77108135
+    starting-at-height-3062757;  ;  ;73801864
+    starting-at-height-3587757;  ;  ;70637360
+    starting-at-height-4112757;  ;  ;67608545
+    starting-at-height-4637757;  ;  ;64709601
+    starting-at-height-5162757;  ;  ;61934959
+    starting-at-height-5687757;  ;  ;59279289
+    starting-at-height-6212757;  ;  ;56737489
+    starting-at-height-6737757;  ;  ;54304678
+    starting-at-height-7262757;  ;  ;51976182
+    starting-at-height-7787757;  ;  ;49747528
+    starting-at-height-8312757;  ;  ;47614435
+    starting-at-height-8837757;  ;  ;45572806
+    starting-at-height-9362757;  ;  ;43618718
+    starting-at-height-9887757;  ;  ;41748419
+    starting-at-height-10412757;  ;  ;39958315
+    starting-at-height-10937757;  ;  ;38244967
+    starting-at-height-11462757;  ;  ;36605085
+    starting-at-height-11987757;  ;  ;35035519
+    starting-at-height-12512757;  ;  ;33533253
+    starting-at-height-13037757;  ;  ;32095402
+    starting-at-height-13562757;  ;  ;30719203
+    starting-at-height-14087757;  ;  ;29402014
+    starting-at-height-14612757;  ;  ;28141304
+    starting-at-height-15137757;  ;  ;26934650
+    starting-at-height-15662757;  ;  ;25779736
+    starting-at-height-16187757;  ;  ;24674343
+    starting-at-height-16712757;  ;  ;23616348
+    starting-at-height-17237757;  ;  ;22603717
+    starting-at-height-17762757;  ;  ;21634507
+    starting-at-height-18287757;  ;  ;20706854
+    starting-at-height-18812757;  ;  ;19818978
+    starting-at-height-19337757;  ;  ;18969173
+    starting-at-height-19862757;  ;  ;18155805
+    starting-at-height-20387757;  ;  ;17377314
+    starting-at-height-20912757;  ;  ;16632203
+    starting-at-height-21437757;  ;  ;15919041
+    starting-at-height-21962757;  ;  ;15236459
+    starting-at-height-22487757;  ;  ;14583144
+    starting-at-height-23012757;  ;  ;13957843
+    starting-at-height-23537757;  ;  ;13359353
+    starting-at-height-24062757;  ;  ;12786526
+    starting-at-height-24587757;  ;  ;12238261
+    starting-at-height-25112757;  ;  ;11713504
+    starting-at-height-25637757;  ;  ;11211248
+    starting-at-height-26162757;  ;  ;10730528
+    starting-at-height-26687757;  ;  ;10270420
+    starting-at-height-27212757;  ;  ;9830041
+    starting-at-height-27737757;  ;  ;9408545
+    starting-at-height-28262757;  ;  ;9005122
+    starting-at-height-28787757;  ;  ;8618997
+    starting-at-height-29312757;  ;  ;8249428
+    starting-at-height-29837757;  ;  ;7895707
+    starting-at-height-30362757;  ;  ;7557151
+    starting-at-height-30887757;  ;  ;7233113
+    starting-at-height-31412757;  ;  ;6922969
+    starting-at-height-31937757;  ;  ;6626123
+    starting-at-height-32462757;  ;  ;6342006
+    starting-at-height-32987757;  ;  ;6070071
+    starting-at-height-33512757;  ;  ;5809796
+    starting-at-height-34037757;  ;  ;5560682
+    starting-at-height-34562757;  ;  ;5322249
+    starting-at-height-35087757;  ;  ;5094039
+    starting-at-height-35612757;  ;  ;4875615
+    starting-at-height-36137757;  ;  ;4666557
+    starting-at-height-36662757;  ;  ;4466462
+    starting-at-height-37187757;  ;  ;4274948
+    starting-at-height-37712757;  ;  ;4091645
+    starting-at-height-38237757;  ;  ;3916202
+    starting-at-height-38762757;  ;  ;3748282
+    starting-at-height-39287757;  ;  ;3587561
+    starting-at-height-39812757;  ;  ;3433732
+    starting-at-height-40337757;  ;  ;3286500
+    starting-at-height-40862757;  ;  ;3145580
+    starting-at-height-41387757;  ;  ;3010703
+    starting-at-height-41912757;  ;  ;2881608
+    starting-at-height-42437757;  ;  ;2758050
+    starting-at-height-42962757;  ;  ;2639789
+    starting-at-height-43487757;  ;  ;2526599
+    starting-at-height-44012757;  ;  ;2418263
+    starting-at-height-44537757;  ;  ;2314572
+    starting-at-height-45062757;  ;  ;2215326
+    starting-at-height-45587757;  ;  ;2120337
+    starting-at-height-46112757;  ;  ;2029420
+    starting-at-height-46637757;  ;  ;1942402
+    starting-at-height-47162757;  ;  ;1859115
+    starting-at-height-47687757;  ;  ;1779399
+    starting-at-height-48212757;  ;  ;1703101
+    starting-at-height-48737757;  ;  ;1630075
+    starting-at-height-49262757;  ;  ;1560180
+    starting-at-height-49787757;  ;  ;1493282
+    starting-at-height-50312757;  ;  ;1429253
+    starting-at-height-50837757;  ;  ;1367969
+    starting-at-height-51362757;  ;  ;1309312
+    starting-at-height-51887757;  ;  ;1253171
+    starting-at-height-52412757;  ;  ;1199437
+    starting-at-height-52937757;  ;  ;1148007
+    starting-at-height-53462757;  ;  ;1098783
+    starting-at-height-53987757;  ;  ;1051669
+    starting-at-height-54512757;  ;  ;1006575
+    starting-at-height-55037757;  ;  ;963414
+    starting-at-height-55562757;  ;  ;922105
+    starting-at-height-56087757;  ;  ;882566
+    starting-at-height-56612757;  ;  ;844723
+    starting-at-height-57137757;  ;  ;808503
+    starting-at-height-57662757;  ;  ;773836
+    starting-at-height-58187757;  ;  ;740655
+    starting-at-height-58712757;  ;  ;708897
+    starting-at-height-59237757;  ;  ;678500
+    starting-at-height-59762757;  ;  ;649407
+    starting-at-height-60287757;  ;  ;621562
+    starting-at-height-60812757;  ;  ;594910
+    starting-at-height-61337757;  ;  ;569401
+    starting-at-height-61862757;  ;  ;544986
+    starting-at-height-62387757;  ;  ;521618
+    starting-at-height-62912757;  ;  ;499252
+    starting-at-height-63437757;  ;  ;477845
+    starting-at-height-63962757;  ;  ;457356
+    starting-at-height-64487757;  ;  ;437745
+    starting-at-height-65012757;  ;  ;418975
+    starting-at-height-65537757;  ;  ;401010
+    starting-at-height-66062757;  ;  ;383816
+    starting-at-height-66587757;  ;  ;367358
+    starting-at-height-67112757;  ;  ;351606
+    starting-at-height-67637757;  ;  ;336530
+    starting-at-height-68162757;  ;  ;322100
+    starting-at-height-68687757;  ;  ;308289
+    starting-at-height-69212757;  ;  ;295070
+    starting-at-height-69737757;  ;  ;282418
+    starting-at-height-70262757;  ;  ;270308
+    starting-at-height-70787757;  ;  ;258718
+    starting-at-height-71312757;  ;  ;247624
+    starting-at-height-71837757;  ;  ;237007
+    starting-at-height-72362757;  ;  ;226844
+    starting-at-height-72887757;  ;  ;217118
+    starting-at-height-73412757;  ;  ;207808
+    starting-at-height-73937757;  ;  ;198897
+    starting-at-height-74462757;  ;  ;190369
+    starting-at-height-74987757;  ;  ;182206
+    starting-at-height-75512757;  ;  ;174394
+    starting-at-height-76037757;  ;  ;166916
+    starting-at-height-76562757;  ;  ;159759
+    starting-at-height-77087757;  ;  ;152908
+    starting-at-height-77612757;  ;  ;146352
+    starting-at-height-78137757;  ;  ;140077
+    starting-at-height-78662757;  ;  ;134070
+    starting-at-height-79187757;  ;  ;128322
+    starting-at-height-79712757;  ;  ;122819
+    starting-at-height-80237757;  ;  ;117553
+    starting-at-height-80762757;  ;  ;112513
+    starting-at-height-81287757;  ;  ;107688
+    starting-at-height-81812757;  ;  ;103071
+    starting-at-height-82337757;  ;  ;98651
+    starting-at-height-82862757;  ;  ;94421
+    starting-at-height-83387757;  ;  ;90372
+    starting-at-height-83912757;  ;  ;86497
+    starting-at-height-84437757;  ;  ;82789
+    starting-at-height-84962757;  ;  ;79239
+    starting-at-height-85487757;  ;  ;75841
+    starting-at-height-86012757;  ;  ;72589
+    starting-at-height-86537757;  ;  ;69477
+    starting-at-height-87062757;  ;  ;66498
+    starting-at-height-87587757;  ;  ;63646
+    starting-at-height-88112757;  ;  ;60917
+    starting-at-height-88637757;  ;  ;58305
+    starting-at-height-89162757;  ;  ;55805
+    starting-at-height-89687757;  ;  ;53412
+    starting-at-height-90212757;  ;  ;51122
+    starting-at-height-90737757;  ;  ;48930
+    starting-at-height-91262757;  ;  ;46832
+    starting-at-height-91787757;  ;  ;44824
+    starting-at-height-92312757;  ;  ;42902
+    starting-at-height-92837757;  ;  ;41062
+    starting-at-height-93362757;  ;  ;39301
+    starting-at-height-93887757;  ;  ;37616
+    starting-at-height-94412757;  ;  ;36003
+    starting-at-height-94937757;  ;  ;34460
+    starting-at-height-95462757;  ;  ;32982
+    starting-at-height-95987757;  ;  ;31568
+    starting-at-height-96512757;  ;  ;30214
+    starting-at-height-97037757;  ;  ;28919
+    starting-at-height-97562757;  ;  ;27679
+    starting-at-height-98087757;  ;  ;26492
+    starting-at-height-98612757;  ;  ;25356
+    starting-at-height-99137757;  ;  ;24269
+    starting-at-height-99662757;  ;  ;23228
+    starting-at-height-100187757;  ;  ;22232
+    starting-at-height-100712757;  ;  ;21279
+    starting-at-height-101237757;  ;  ;20366
+    starting-at-height-101762757;  ;  ;19493
+    starting-at-height-102287757;  ;  ;18657
+    starting-at-height-102812757;  ;  ;17857
+    starting-at-height-103337757;  ;  ;17091
+    starting-at-height-103862757;  ;  ;16358
+    starting-at-height-104387757;  ;  ;15657
+    starting-at-height-104912757;  ;  ;14986
+    starting-at-height-105437757;  ;  ;14343
+    starting-at-height-105962757;  ;  ;13728
+    starting-at-height-106487757;  ;  ;13139
+    starting-at-height-107012757;  ;  ;12576
+    starting-at-height-107537757;  ;  ;12037
+    starting-at-height-108062757;  ;  ;11521
+    starting-at-height-108587757;  ;  ;11027
+    starting-at-height-109112757;  ;  ;10554
+    starting-at-height-109637757;  ;  ;10101
+    starting-at-height-110162757;  ;  ;9668
+    starting-at-height-110687757;  ;  ;9254
+    starting-at-height-111212757;  ;  ;8857
+    starting-at-height-111737757;  ;  ;8477
+    starting-at-height-112262757;  ;  ;8113
+    starting-at-height-112787757;  ;  ;7766
+    starting-at-height-113312757;  ;  ;7433
+    starting-at-height-113837757;  ;  ;7114
+    starting-at-height-114362757;  ;  ;6809
+    starting-at-height-114887757;  ;  ;6517
+    starting-at-height-115412757;  ;  ;6237
+    starting-at-height-115937757;  ;  ;5970
+    starting-at-height-116462757;  ;  ;5714
+    starting-at-height-116987757;  ;  ;5469
+    starting-at-height-117512757;  ;  ;5234
+    starting-at-height-118037757;  ;  ;5010
+    starting-at-height-118562757;  ;  ;4795
+    starting-at-height-119087757;  ;  ;4589
+    starting-at-height-119612757;  ;  ;4393
+    starting-at-height-120137757;  ;  ;4204
+    starting-at-height-120662757;  ;  ;4024
+    starting-at-height-121187757;  ;  ;3851
+    starting-at-height-121712757;  ;  ;3686
+    starting-at-height-122237757;  ;  ;3528
+    starting-at-height-122762757;  ;  ;3377
+    starting-at-height-123287757;  ;  ;3232
+    starting-at-height-123812757;  ;  ;3093
+    starting-at-height-124337757;  ;  ;2961
+    starting-at-height-124862757;  ;  ;2834
+    starting-at-height-125387757;  ;  ;2712
+    starting-at-height-125912757;  ;  ;2596
+    starting-at-height-126437757;  ;  ;2485
+    starting-at-height-126962757;  ;  ;2378
+    starting-at-height-127487757;  ;  ;2276
+    starting-at-height-128012757;  ;  ;2178
+    starting-at-height-128537757;  ;  ;2085
+    starting-at-height-129062757;  ;  ;1996
+    starting-at-height-129587757;  ;  ;1910
+    starting-at-height-130112757;  ;  ;1828
+    starting-at-height-130637757;  ;  ;1750
+    starting-at-height-131162757;  ;  ;1675
+    starting-at-height-131687757;  ;  ;1603
+    starting-at-height-132212757;  ;  ;1534
+    starting-at-height-132737757;  ;  ;1468
+    starting-at-height-133262757;  ;  ;1405
+    starting-at-height-133787757;  ;  ;1345
+    starting-at-height-134312757;  ;  ;1287
+    starting-at-height-134837757;  ;  ;1232
+    starting-at-height-135362757;  ;  ;1179
+    starting-at-height-135887757;  ;  ;1129
+    starting-at-height-136412757;  ;  ;1080
+    starting-at-height-136937757;  ;  ;1034
+    starting-at-height-137462757;  ;  ;990
+    starting-at-height-137987757;  ;  ;947
+    starting-at-height-138512757;  ;  ;907
+    starting-at-height-139037757;  ;  ;868
+    starting-at-height-139562757;  ;  ;830
+    starting-at-height-140087757;  ;  ;795
+    starting-at-height-140612757;  ;  ;761
+    starting-at-height-141137757;  ;  ;728
+    starting-at-height-141662757;  ;  ;697
+    starting-at-height-142187757;  ;  ;667
+    starting-at-height-142712757;  ;  ;638
+    starting-at-height-143237757;  ;  ;611
+    starting-at-height-143762757;  ;  ;585
+    starting-at-height-144287757;  ;  ;560
+    starting-at-height-144812757;  ;  ;536
+    starting-at-height-145337757;  ;  ;513
+    starting-at-height-145862757;  ;  ;491
+    starting-at-height-146387757;  ;  ;470
+    starting-at-height-146912757;  ;  ;449
+    starting-at-height-147437757;  ;  ;430
+    starting-at-height-147962757;  ;  ;412
+    starting-at-height-148487757;  ;  ;394
+    starting-at-height-149012757;  ;  ;377
+    starting-at-height-149537757;  ;  ;361
+    starting-at-height-150062757;  ;  ;345
+    starting-at-height-150587757;  ;  ;331
+    starting-at-height-151112757;  ;  ;316
+    starting-at-height-151637757;  ;  ;303
+    starting-at-height-152162757;  ;  ;290
+    starting-at-height-152687757;  ;  ;277
+    starting-at-height-153212757;  ;  ;265
+    starting-at-height-153737757;  ;  ;254
+    starting-at-height-154262757;  ;  ;243
+    starting-at-height-154787757;  ;  ;233
+    starting-at-height-155312757;  ;  ;223
+    starting-at-height-155837757;  ;  ;213
+    starting-at-height-156362757;  ;  ;204
+    starting-at-height-156887757;  ;  ;195
+    starting-at-height-157412757;  ;  ;187
+    starting-at-height-157937757;  ;  ;179
+    starting-at-height-158462757;  ;  ;171
+    starting-at-height-158987757;  ;  ;164
+    starting-at-height-159512757;  ;  ;157
+    starting-at-height-160037757;  ;  ;150
+    starting-at-height-160562757;  ;  ;143
+    starting-at-height-161087757;  ;  ;137
+    starting-at-height-161612757;  ;  ;131
+    starting-at-height-162137757;  ;  ;126
+    starting-at-height-162662757;  ;  ;120
+    starting-at-height-163187757;  ;  ;115
+    starting-at-height-163712757;  ;  ;110
+    starting-at-height-164237757;  ;  ;105
+    starting-at-height-164762757;  ;  ;101
+    starting-at-height-165287757;  ;  ;97
+    starting-at-height-165812757;  ;  ;92
+    starting-at-height-166337757;  ;  ;88
+    starting-at-height-166862757;  ;  ;85
+    starting-at-height-167387757;  ;  ;81
+    starting-at-height-167912757;  ;  ;77
+    starting-at-height-168437757;  ;  ;74
+    starting-at-height-168962757;  ;  ;71
+    starting-at-height-169487757;  ;  ;68
+    starting-at-height-170012757;  ;  ;65
+    starting-at-height-170537757;  ;  ;62
+    starting-at-height-171062757;  ;  ;59
+    starting-at-height-171587757;  ;  ;57
+    starting-at-height-172112757;  ;  ;54
+    starting-at-height-172637757;  ;  ;52
+    starting-at-height-173162757;  ;  ;50
+    starting-at-height-173687757;  ;  ;48
+    starting-at-height-174212757;  ;  ;46
+    starting-at-height-174737757;  ;  ;44
+    starting-at-height-175262757;  ;  ;42
+    starting-at-height-175787757;  ;  ;40
+    starting-at-height-176312757;  ;  ;38
+    starting-at-height-176837757;  ;  ;37
+    starting-at-height-177362757;  ;  ;35
+    starting-at-height-177887757;  ;  ;33
+    starting-at-height-178412757;  ;  ;32
+    starting-at-height-178937757;  ;  ;31
+    starting-at-height-179462757;  ;  ;29
+    starting-at-height-179987757;  ;  ;28
+    starting-at-height-180512757;  ;  ;27
+    starting-at-height-181037757;  ;  ;26
+    starting-at-height-181562757;  ;  ;24
+    starting-at-height-182087757;  ;  ;23
+    starting-at-height-182612757;  ;  ;22
+    starting-at-height-183137757;  ;  ;21
+    starting-at-height-183662757;  ;  ;20
+    starting-at-height-184187757;  ;  ;20
+    starting-at-height-184712757;  ;  ;19
+    starting-at-height-185237757;  ;  ;18
+    starting-at-height-185762757;  ;  ;17
+    starting-at-height-186287757;  ;  ;16
+    starting-at-height-186812757;  ;  ;16
+    starting-at-height-187337757;  ;  ;15
+    starting-at-height-187862757;  ;  ;14
+    starting-at-height-188387757;  ;  ;14
+    starting-at-height-188912757;  ;  ;13
+    starting-at-height-189437757;  ;  ;12
+    starting-at-height-189962757;  ;  ;12
+    starting-at-height-190487757;  ;  ;11
+    starting-at-height-191012757;  ;  ;11
+    starting-at-height-191537757;  ;  ;10
+    starting-at-height-192062757;  ;  ;10
+    starting-at-height-192587757;  ;  ;9
+    starting-at-height-193112757;  ;  ;9
+    starting-at-height-193637757;  ;  ;9
+    starting-at-height-194162757;  ;  ;8
+    starting-at-height-194687757;  ;  ;8
+    starting-at-height-195212757;  ;  ;8
+    starting-at-height-195737757;  ;  ;7
+    starting-at-height-196262757;  ;  ;7
+    starting-at-height-196787757;  ;  ;7
+    starting-at-height-197312757;  ;  ;6
+    starting-at-height-197837757;  ;  ;6
+    starting-at-height-198362757;  ;  ;6
+    starting-at-height-198887757;  ;  ;5
+    starting-at-height-199412757;  ;  ;5
+    starting-at-height-199937757;  ;  ;5
+    starting-at-height-200462757;  ;  ;5
+    starting-at-height-200987757;  ;  ;4
+    starting-at-height-201512757;  ;  ;4
+    starting-at-height-202037757;  ;  ;4
+    starting-at-height-202562757;  ;  ;4
+    starting-at-height-203087757;  ;  ;4
+    starting-at-height-203612757;  ;  ;4
+    starting-at-height-204137757;  ;  ;3
+    starting-at-height-204662757;  ;  ;3
+    starting-at-height-205187757;  ;  ;3
+    starting-at-height-205712757;  ;  ;3
+    starting-at-height-206237757;  ;  ;3
+    starting-at-height-206762757;  ;  ;3
+    starting-at-height-207287757;  ;  ;2
+    starting-at-height-207812757;  ;  ;2
+    starting-at-height-208337757;  ;  ;2
+    starting-at-height-208862757;  ;  ;2
+    starting-at-height-209387757;  ;  ;2
+    starting-at-height-209912757;  ;  ;2
+    starting-at-height-210437757;  ;  ;2
+    starting-at-height-210962757;  ;  ;2
+    starting-at-height-211487757;  ;  ;2
+    starting-at-height-212012757;  ;  ;2
+    starting-at-height-212537757;  ;  ;1
+    starting-at-height-213062757;  ;  ;1
+    starting-at-height-213587757;  ;  ;1
+    starting-at-height-214112757;  ;  ;1
+    starting-at-height-214637757;  ;  ;1
+    starting-at-height-215162757;  ;  ;1
+    starting-at-height-215687757;  ;  ;1
+    starting-at-height-216212757;  ;  ;1
+    starting-at-height-216737757;  ;  ;1
+    starting-at-height-217262757;  ;  ;1
+    starting-at-height-217787757;  ;  ;1
+    starting-at-height-218312757;  ;  ;1
+    starting-at-height-218837757;  ;  ;1
+    starting-at-height-219362757;  ;  ;1
+    starting-at-height-219887757;  ;  ;1
+    starting-at-height-220412757;  ;  ;1
+    starting-at-height-220937757;  ;  ;0
+
+config-logging-broker.properties
+================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **console**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    colorMode;  ;  ;Ansi
+    **console.component.levels**; ; ;
+    **file**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    directory;  ;  ;logs
+    filePattern;  ;  ;logs/catapult_broker%4N.log
+    rotationSize;  ;  ;25MB
+    maxTotalSize;  ;  ;2500MB
+    minFreeSpace;  ;  ;100MB
+    **file.component.levels**; ; ;
+
+config-logging-recovery.properties
+==================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **console**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    colorMode;  ;  ;Ansi
+    **console.component.levels**; ; ;
+    **file**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    directory;  ;  ;logs
+    filePattern;  ;  ;logs/catapult_recovery%4N.log
+    rotationSize;  ;  ;25MB
+    maxTotalSize;  ;  ;2500MB
+    minFreeSpace;  ;  ;100MB
+    **file.component.levels**; ; ;
+
+config-logging-server.properties
+================================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **console**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    colorMode;  ;  ;Ansi
+    **console.component.levels**; ; ;
+    **file**; ; ;
+    sinkType;  ;  ;Async
+    level;  ;  ;Info
+    directory;  ;  ;logs
+    filePattern;  ;  ;logs/catapult_server%4N.log
+    rotationSize;  ;  ;25MB
+    maxTotalSize;  ;  ;2500MB
+    minFreeSpace;  ;  ;100MB
+    **file.component.levels**; ; ;
+
+config-messaging.properties
+===========================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **messaging**; ; ;
+    subscriberPort;  ;  ;7902
+
+config-network.properties
+=========================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **network**; ; ;
+    identifier; NetworkIdentifier ; Network identifier. ;public-test
+    nemesisSignerPublicKey; Key ; Nemesis public key. ;78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0
+    nodeEqualityStrategy; NodeIdentityEqualityStrategy ; Node equality strategy. ;host
+    generationHashSeed;  ;  ;6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD
+    epochAdjustment; utils::TimeSpan ; Nemesis epoch time adjustment. ;1573430400s
+    **chain**; ; ;
+    enableVerifiableState; bool ; Set to true if block chain should calculate state hashes so that state is fully verifiable at each block. ;true
+    enableVerifiableReceipts; bool ; Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block. ;true
+    currencyMosaicId; MosaicId ; Mosaic id used as primary chain currency. ;0x5B66'E76B'ECAD'0860
+    harvestingMosaicId; MosaicId ; Mosaic id used to provide harvesting ability. ;0x5B66'E76B'ECAD'0860
+    blockGenerationTargetTime; utils::TimeSpan ; Targeted time between blocks. ;30s
+    blockTimeSmoothingFactor; uint32_t ; Note: A higher value makes the network more biased. Note: This can lower security because it will increase the influence of time relative to importance. ;3000
+    importanceGrouping; uint64_t ; Number of blocks that should be treated as a group for importance purposes. Note: Importances will only be calculated at blocks that are multiples of this grouping number. ;180
+    importanceActivityPercentage; uint8_t ; Percentage of importance resulting from fee generation and beneficiary usage. ;5
+    maxRollbackBlocks; uint32_t ; Maximum number of blocks that can be rolled back. ;0
+    maxDifficultyBlocks; uint32_t ; Maximum number of blocks to use in a difficulty calculation. ;60
+    defaultDynamicFeeMultiplier; BlockFeeMultiplier ; Default multiplier to use for dynamic fees. ;1'000
+    maxTransactionLifetime; utils::TimeSpan ; Maximum lifetime a transaction can have before it expires. ;6h
+    maxBlockFutureTime; utils::TimeSpan ; Maximum future time of a block that can be accepted. ;500ms
+    initialCurrencyAtomicUnits; Amount ; Initial currency atomic units available in the network. ;7'831'975'436'000'000
+    maxMosaicAtomicUnits; Amount ; Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network. ;9'000'000'000'000'000
+    totalChainImportance; Importance ; Total whole importance units available in the network. ;7'831'975'436'000'000
+    minHarvesterBalance; Amount ; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting. ;10'000'000'000
+    maxHarvesterBalance; Amount ; Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting. ;50'000'000'000'000
+    minVoterBalance; Amount ; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting. ;3'000'000'000'000
+    votingSetGrouping;  ;  ;720
+    maxVotingKeysPerAccount; uint8_t ; Maximum number of voting keys that can be registered at once per account. ;3
+    minVotingKeyLifetime; uint32_t ; Minimum number of finalization rounds for which voting key can be registered. ;28
+    maxVotingKeyLifetime; uint32_t ; Maximum number of finalization rounds for which voting key can be registered. ;26280
+    harvestBeneficiaryPercentage; uint8_t ; Percentage of the harvested fee that is collected by the beneficiary account. ;25
+    harvestNetworkPercentage; uint8_t ; Percentage of the harvested fee that is collected by the network. ;5
+    harvestNetworkFeeSinkAddress; Address ; Address of the harvest network fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
+    maxTransactionsPerBlock; uint32_t ; Maximum number of transactions per block. ;6'000
+    **plugin:catapult.plugins.accountlink**; ; ;
+    dummy;  ;  ;to trigger plugin load
+    **plugin:catapult.plugins.aggregate**; ; ;
+    maxTransactionsPerAggregate; uint32_t ; Maximum number of transactions per aggregate. ;100
+    maxCosignaturesPerAggregate; uint8_t ; Maximum number of cosignatures per aggregate. ;25
+    enableStrictCosignatureCheck; bool ; Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally. ;false
+    enableBondedAggregateSupport; bool ; Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected. ;true
+    maxBondedTransactionLifetime; utils::TimeSpan ; Maximum lifetime a bonded transaction can have before it expires. ;48h
+    **plugin:catapult.plugins.lockhash**; ; ;
+    lockedFundsPerAggregate; Amount ; Amount that has to be locked per aggregate in partial cache. ;10'000'000
+    maxHashLockDuration; utils::BlockSpan ; Maximum number of blocks for which a hash lock can exist. ;2d
+    **plugin:catapult.plugins.locksecret**; ; ;
+    maxSecretLockDuration; utils::BlockSpan ; Maximum number of blocks for which a secret lock can exist. ;365d
+    minProofSize; uint16_t ; Minimum size of a proof in bytes. ;20
+    maxProofSize; uint16_t ; Maximum size of a proof in bytes. ;1024
+    **plugin:catapult.plugins.metadata**; ; ;
+    maxValueSize; uint16_t ; Maximum metadata value size. ;1024
+    **plugin:catapult.plugins.mosaic**; ; ;
+    maxMosaicsPerAccount; uint16_t ; Maximum number of mosaics that an account can own. ;1'000
+    maxMosaicDuration; utils::BlockSpan ; Maximum mosaic duration. ;3650d
+    maxMosaicDivisibility; uint8_t ; Maximum mosaic divisibility. ;6
+    mosaicRentalFeeSinkAddress; Address ; Address of the mosaic rental fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
+    mosaicRentalFee; Amount ; Mosaic rental fee. ;500
+    **plugin:catapult.plugins.multisig**; ; ;
+    maxMultisigDepth; uint8_t ; Maximum number of multisig levels. ;3
+    maxCosignatoriesPerAccount; uint32_t ; Maximum number of cosignatories per account. ;25
+    maxCosignedAccountsPerAccount; uint32_t ; Maximum number of accounts a single account can cosign. ;25
+    **plugin:catapult.plugins.namespace**; ; ;
+    maxNameSize; uint8_t ; Maximum namespace name size. ;64
+    maxChildNamespaces; uint16_t ; Maximum number of children for a root namespace. ;256
+    maxNamespaceDepth; uint8_t ; Maximum namespace depth. ;3
+    minNamespaceDuration; utils::BlockSpan ; Minimum namespace duration. ;30d
+    maxNamespaceDuration; utils::BlockSpan ; Maximum namespace duration. ;1825d
+    namespaceGracePeriodDuration; utils::BlockSpan ; Grace period during which time only the previous owner can renew an expired namespace. ;1d
+    reservedRootNamespaceNames; unordered_set<string> ; Reserved root namespaces that cannot be claimed. ;symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info
+    namespaceRentalFeeSinkAddress; Address ; Address of the namespace rental fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
+    rootNamespaceRentalFeePerBlock; Amount ; Root namespace rental fee per block. ;1
+    childNamespaceRentalFee; Amount ; Child namespace rental fee. ;100
+    **plugin:catapult.plugins.restrictionaccount**; ; ;
+    maxAccountRestrictionValues; uint16_t ; Maximum number of account restriction values. ;512
+    **plugin:catapult.plugins.restrictionmosaic**; ; ;
+    maxMosaicRestrictionValues; uint8_t ; Maximum number of mosaic restriction values. ;20
+    **plugin:catapult.plugins.transfer**; ; ;
+    maxMessageSize; uint16_t ; Maximum transaction message size. ;1024
+
+config-networkheight.properties
+===============================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **networkheight**; ; ;
+    maxNodes;  ;  ;5
+
+config-node.properties
+======================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **node**; ; ;
+    port; unsigned short ; Server port. ;7900
+    maxIncomingConnectionsPerIdentity; uint32_t ; Maximum number of incoming connections per identity over primary port. ;6
+    enableAddressReuse; bool ; Set to true if the server should reuse ports already in use. ;false
+    enableSingleThreadPool; bool ; Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used. ;false
+    enableCacheDatabaseStorage; bool ; Set to true if cache data should be saved in a database. ;true
+    enableAutoSyncCleanup; bool ; Set to true if temporary sync files should be automatically cleaned up. Note: This should be Set to false if broker process is running. ;false
+    enableTransactionSpamThrottling; bool ; Set to true if transaction spam throttling should be enabled. ;true
+    transactionSpamThrottlingMaxBoostFee; Amount ; Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled. ;10'000'000
+    maxHashesPerSyncAttempt;  ;  ;610
+    maxBlocksPerSyncAttempt; uint32_t ; Maximum number of blocks per sync attempt. ;602
+    maxChainBytesPerSyncAttempt; utils::FileSize ; Maximum chain bytes per sync attempt. ;100MB
+    shortLivedCacheTransactionDuration; utils::TimeSpan ; Duration of a transaction in the short lived cache. ;10m
+    shortLivedCacheBlockDuration; utils::TimeSpan ; Duration of a block in the short lived cache. ;100m
+    shortLivedCachePruneInterval; utils::TimeSpan ; Time between short lived cache pruning. ;90s
+    shortLivedCacheMaxSize; uint32_t ; Maximum size of a short lived cache. ;200'000
+    minFeeMultiplier; BlockFeeMultiplier ; Minimum fee multiplier of transactions to propagate and include in blocks. ;100
+    transactionSelectionStrategy; model::TransactionSelectionStrategy ; Transaction selection strategy used for syncing and harvesting unconfirmed transactions. ;maximize-fee
+    unconfirmedTransactionsCacheMaxResponseSize; utils::FileSize ; Maximum size of an unconfirmed transactions response. ;20MB
+    unconfirmedTransactionsCacheMaxSize; uint32_t ; Maximum size of the unconfirmed transactions cache. ;50'000
+    connectTimeout; utils::TimeSpan ; Timeout for connecting to a peer. ;15s
+    syncTimeout; utils::TimeSpan ; Timeout for syncing with a peer. ;120s
+    socketWorkingBufferSize; utils::FileSize ; Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size). ;512KB
+    socketWorkingBufferSensitivity; uint32_t ; Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). Note: Set to 0 will disable memory reclamation. ;100
+    maxPacketDataSize; utils::FileSize ; Maximum packet data size. ;150MB
+    blockDisruptorSize; uint32_t ; Size of the block disruptor circular buffer. ;4096
+    blockElementTraceInterval; uint32_t ; Multiple of elements at which a block element should be traced through queue and completion. ;1
+    transactionDisruptorSize; uint32_t ; Size of the transaction disruptor circular buffer. ;16384
+    transactionElementTraceInterval; uint32_t ; Multiple of elements at which a transaction element should be traced through queue and completion. ;10
+    enableDispatcherAbortWhenFull; bool ; Set to true if the process should terminate when any dispatcher is full. ;false
+    enableDispatcherInputAuditing; bool ; Set to true if all dispatcher inputs should be audited. ;false
+    maxCacheDatabaseWriteBatchSize; utils::FileSize ; Maximum cache database write batch size. ;5MB
+    maxTrackedNodes; uint32_t ; Maximum number of nodes to track in memory. ;5'000
+    trustedHosts; unordered_set<string> ; Trusted hosts that are allowed to execute protected API calls on this node. ;
+    localNetworks; unordered_set<string> ; Networks that should be treated as local. ;127.0.0.1, 172.20.0.25
+    **localnode**; ; ;
+    host; string ; Node host (leave empty to auto-detect IP). ;
+    friendlyName; string ; Node friendly name (leave empty to use address). ;myFriendlyName
+    version; uint32_t ; Node version. ;0
+    roles; ionet::NodeRoles ; Node roles. ;Api,Peer,Voting
+    **outgoing_connections**; ; ;
+    maxConnections; uint16_t ; Maximum number of active connections. ;10
+    maxConnectionAge; uint16_t ; Maximum connection age. ;200
+    maxConnectionBanAge; uint16_t ; Maximum connection ban age. ;20
+    numConsecutiveFailuresBeforeBanning; uint16_t ; Number of consecutive connection failures before a connection is banned. ;3
+    **incoming_connections**; ; ;
+    maxConnections; uint16_t ; Maximum number of active connections. ;512
+    maxConnectionAge; uint16_t ; Maximum connection age. ;200
+    maxConnectionBanAge; uint16_t ; Maximum connection ban age. ;20
+    numConsecutiveFailuresBeforeBanning; uint16_t ; Number of consecutive connection failures before a connection is banned. ;3
+    backlogSize; uint16_t ; Maximum size of the pending connections queue. ;512
+    **banning**; ; ;
+    defaultBanDuration; utils::TimeSpan ; Default duration for banning. ;12h
+    maxBanDuration; utils::TimeSpan ; Maximum duration for banning. ;12h
+    keepAliveDuration; utils::TimeSpan ; Duration to keep account in container after the ban expired. ;48h
+    maxBannedNodes; uint32_t ; Maximum number of banned nodes. ;5'000
+    numReadRateMonitoringBuckets; uint16_t ; Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring). ;4
+    readRateMonitoringBucketDuration; utils::TimeSpan ; Duration of each read rate monitoring bucket. ;15s
+    maxReadRateMonitoringTotalSize; utils::FileSize ; Maximum size allowed during full read rate monitoring period. ;100MB
+
+config-pt.properties
+====================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **partialtransactions**; ; ;
+    cacheMaxResponseSize;  ;  ;20MB
+    cacheMaxSize;  ;  ;1'000'000
+
+config-task.properties
+======================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **logging task**; ; ;
+    startDelay;  ;  ;1m
+    repeatDelay;  ;  ;10m
+    **connect peers task for service Finalization**; ; ;
+    startDelay;  ;  ;2s
+    repeatDelay;  ;  ;1m
+    **finalization task**; ; ;
+    startDelay;  ;  ;2m
+    repeatDelay;  ;  ;15s
+    **pull finalization messages task**; ; ;
+    startDelay;  ;  ;3s
+    repeatDelay;  ;  ;1s
+    **pull finalization proof task**; ; ;
+    startDelay;  ;  ;10s
+    repeatDelay;  ;  ;50s
+    **harvesting task**; ; ;
+    startDelay;  ;  ;30s
+    repeatDelay;  ;  ;1s
+    **network chain height detection**; ; ;
+    startDelay;  ;  ;1s
+    repeatDelay;  ;  ;15s
+    **node discovery peers task**; ; ;
+    startDelay;  ;  ;1m
+    minDelay;  ;  ;1m
+    maxDelay;  ;  ;10m
+    numPhaseOneRounds;  ;  ;10
+    numTransitionRounds;  ;  ;20
+    **node discovery ping task**; ; ;
+    startDelay;  ;  ;2m
+    repeatDelay;  ;  ;5m
+    **age peers task for service Readers**; ; ;
+    startDelay;  ;  ;1m
+    repeatDelay;  ;  ;1m
+    **batch partial transaction task**; ; ;
+    startDelay;  ;  ;500ms
+    repeatDelay;  ;  ;500ms
+    **connect peers task for service Pt**; ; ;
+    startDelay;  ;  ;3s
+    repeatDelay;  ;  ;1m
+    **pull partial transactions task**; ; ;
+    startDelay;  ;  ;10s
+    repeatDelay;  ;  ;3s
+    **batch transaction task**; ; ;
+    startDelay;  ;  ;500ms
+    repeatDelay;  ;  ;500ms
+    **connect peers task for service Sync**; ; ;
+    startDelay;  ;  ;1s
+    repeatDelay;  ;  ;1m
+    **pull unconfirmed transactions task**; ; ;
+    startDelay;  ;  ;4s
+    repeatDelay;  ;  ;3s
+    **synchronizer task**; ; ;
+    startDelay;  ;  ;3s
+    repeatDelay;  ;  ;3s
+    **time synchronization task**; ; ;
+    startDelay;  ;  ;1m
+    minDelay;  ;  ;3m
+    maxDelay;  ;  ;180m
+    numPhaseOneRounds;  ;  ;5
+    numTransitionRounds;  ;  ;10
+    **static node refresh task**; ; ;
+    startDelay;  ;  ;5ms
+    minDelay;  ;  ;15s
+    maxDelay;  ;  ;24h
+    numPhaseOneRounds;  ;  ;20
+    numTransitionRounds;  ;  ;20
+
+config-timesync.properties
+==========================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **timesynchronization**; ; ;
+    maxNodes;  ;  ;20
+    minImportance;  ;  ;3'750
+
+config-user.properties
+======================
+.. csv-table::
+    :header: "Property", "Type", "Description", "Value"
+    :delim: ;
+
+    **account**; ; ;
+    enableDelegatedHarvestersAutoDetection;  ;  ;true
+    **storage**; ; ;
+    certificateDirectory;  ;  ;/userconfig/resources/cert
+    dataDirectory;  ;  ;/data
+    pluginsDirectory;  ;  ;/usr/catapult/lib
+    votingKeysDirectory;  ;  ;/data/votingkeys

--- a/test/expected-api-node-config.rst
+++ b/test/expected-api-node-config.rst
@@ -1,874 +1,873 @@
-
 config-database.properties
 ==========================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **database**; ; ;
-    databaseUri;  ;  ;mongodb://db:27017
-    databaseName;  ;  ;catapult
-    maxWriterThreads;  ;  ;8
-    **plugins**; ; ;
-    catapult.mongo.plugins.accountlink;  ;  ;true
-    catapult.mongo.plugins.aggregate;  ;  ;true
-    catapult.mongo.plugins.lockhash;  ;  ;true
-    catapult.mongo.plugins.locksecret;  ;  ;true
-    catapult.mongo.plugins.metadata;  ;  ;true
-    catapult.mongo.plugins.mosaic;  ;  ;true
-    catapult.mongo.plugins.multisig;  ;  ;true
-    catapult.mongo.plugins.namespace;  ;  ;true
-    catapult.mongo.plugins.restrictionaccount;  ;  ;true
-    catapult.mongo.plugins.restrictionmosaic;  ;  ;true
-    catapult.mongo.plugins.transfer;  ;  ;true
+    **database**;
+    databaseUri; mongodb://db:27017
+    databaseName; catapult
+    maxWriterThreads; 8
+    **plugins**;
+    catapult.mongo.plugins.accountlink; true
+    catapult.mongo.plugins.aggregate; true
+    catapult.mongo.plugins.lockhash; true
+    catapult.mongo.plugins.locksecret; true
+    catapult.mongo.plugins.metadata; true
+    catapult.mongo.plugins.mosaic; true
+    catapult.mongo.plugins.multisig; true
+    catapult.mongo.plugins.namespace; true
+    catapult.mongo.plugins.restrictionaccount; true
+    catapult.mongo.plugins.restrictionmosaic; true
+    catapult.mongo.plugins.transfer; true
 
 config-extensions-broker.properties
 ===================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **extensions**; ; ;
-    extension.addressextraction;  ;  ;true
-    extension.mongo;  ;  ;true
-    extension.zeromq;  ;  ;true
-    extension.hashcache;  ;  ;true
+    **extensions**;
+    extension.addressextraction; true
+    extension.mongo; true
+    extension.zeromq; true
+    extension.hashcache; true
 
 config-extensions-recovery.properties
 =====================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **extensions**; ; ;
-    extension.addressextraction;  ;  ;true
-    extension.mongo;  ;  ;true
-    extension.zeromq;  ;  ;true
-    extension.hashcache;  ;  ;true
+    **extensions**;
+    extension.addressextraction; true
+    extension.mongo; true
+    extension.zeromq; true
+    extension.hashcache; true
 
 config-extensions-server.properties
 ===================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **extensions**; ; ;
-    extension.filespooling;  ;  ;true
-    extension.partialtransaction;  ;  ;true
-    extension.addressextraction;  ;  ;false
-    extension.mongo;  ;  ;false
-    extension.zeromq;  ;  ;false
-    extension.eventsource;  ;  ;false
-    extension.harvesting;  ;  ;true
-    extension.syncsource;  ;  ;true
-    extension.diagnostics;  ;  ;true
-    extension.finalization;  ;  ;true
-    extension.hashcache;  ;  ;true
-    extension.networkheight;  ;  ;false
-    extension.nodediscovery;  ;  ;true
-    extension.packetserver;  ;  ;true
-    extension.pluginhandlers;  ;  ;true
-    extension.sync;  ;  ;true
-    extension.timesync;  ;  ;true
-    extension.transactionsink;  ;  ;true
-    extension.unbondedpruning;  ;  ;true
+    **extensions**;
+    extension.filespooling; true
+    extension.partialtransaction; true
+    extension.addressextraction; false
+    extension.mongo; false
+    extension.zeromq; false
+    extension.eventsource; false
+    extension.harvesting; true
+    extension.syncsource; true
+    extension.diagnostics; true
+    extension.finalization; true
+    extension.hashcache; true
+    extension.networkheight; false
+    extension.nodediscovery; true
+    extension.packetserver; true
+    extension.pluginhandlers; true
+    extension.sync; true
+    extension.timesync; true
+    extension.transactionsink; true
+    extension.unbondedpruning; true
 
 config-finalization.properties
 ==============================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **finalization**; ; ;
-    enableVoting;  ;  ;true
-    size;  ;  ;10'000
-    threshold;  ;  ;7'000
-    stepDuration;  ;  ;4m
-    shortLivedCacheMessageDuration;  ;  ;10m
-    messageSynchronizationMaxResponseSize;  ;  ;20MB
-    maxHashesPerPoint;  ;  ;256
-    prevoteBlocksMultiple;  ;  ;4
-    votingKeyDilution;  ;  ;128
+    **finalization**;
+    enableVoting; true
+    size; 10'000
+    threshold; 7'000
+    stepDuration; 4m
+    shortLivedCacheMessageDuration; 10m
+    messageSynchronizationMaxResponseSize; 20MB
+    maxHashesPerPoint; 256
+    prevoteBlocksMultiple; 4
+    votingKeyDilution; 128
 
 config-harvesting.properties
 ============================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value", "Type", "Description"
     :delim: ;
 
     **harvesting**; ; ;
-    harvesterSigningPrivateKey; string ; Harvester signing private key. ;19CBD6AE842F9FDDC8F6F2AE8081981CF2268435BACA6A8A6A91740D631494BD
-    harvesterVrfPrivateKey; string ; Harvester vrf private key. ;620857FB100B5F34379DAD160C9A43D6B1BDC562D83DC37A468DD99D31C830F6
-    enableAutoHarvesting; bool ; Set to true if auto harvesting is enabled. ;true
-    maxUnlockedAccounts; uint32_t ; Maximum number of unlocked accounts. ;5
-    delegatePrioritizationPolicy; harvesting::DelegatePrioritizationPolicy ; Delegate harvester prioritization policy. ;Importance
-    beneficiaryAddress; Address ; Address of the account receiving part of the harvested fee. ;
+    harvesterSigningPrivateKey; ****************************************************************; string; Harvester signing private key.
+    harvesterVrfPrivateKey; ****************************************************************; string; Harvester vrf private key.
+    enableAutoHarvesting; true; bool; Set to true if auto harvesting is enabled.
+    maxUnlockedAccounts; 5; uint32_t; Maximum number of unlocked accounts.
+    delegatePrioritizationPolicy; Importance; harvesting::DelegatePrioritizationPolicy; Delegate harvester prioritization policy.
+    beneficiaryAddress; ; Address; Address of the account receiving part of the harvested fee.
 
 config-inflation.properties
 ===========================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **inflation**; ; ;
-    starting-at-height-2;  ;  ;95998521
-    starting-at-height-200;  ;  ;91882261
-    starting-at-height-400;  ;  ;87942499
-    starting-at-height-600;  ;  ;84171668
-    starting-at-height-800;  ;  ;80562525
-    starting-at-height-2537757;  ;  ;77108135
-    starting-at-height-3062757;  ;  ;73801864
-    starting-at-height-3587757;  ;  ;70637360
-    starting-at-height-4112757;  ;  ;67608545
-    starting-at-height-4637757;  ;  ;64709601
-    starting-at-height-5162757;  ;  ;61934959
-    starting-at-height-5687757;  ;  ;59279289
-    starting-at-height-6212757;  ;  ;56737489
-    starting-at-height-6737757;  ;  ;54304678
-    starting-at-height-7262757;  ;  ;51976182
-    starting-at-height-7787757;  ;  ;49747528
-    starting-at-height-8312757;  ;  ;47614435
-    starting-at-height-8837757;  ;  ;45572806
-    starting-at-height-9362757;  ;  ;43618718
-    starting-at-height-9887757;  ;  ;41748419
-    starting-at-height-10412757;  ;  ;39958315
-    starting-at-height-10937757;  ;  ;38244967
-    starting-at-height-11462757;  ;  ;36605085
-    starting-at-height-11987757;  ;  ;35035519
-    starting-at-height-12512757;  ;  ;33533253
-    starting-at-height-13037757;  ;  ;32095402
-    starting-at-height-13562757;  ;  ;30719203
-    starting-at-height-14087757;  ;  ;29402014
-    starting-at-height-14612757;  ;  ;28141304
-    starting-at-height-15137757;  ;  ;26934650
-    starting-at-height-15662757;  ;  ;25779736
-    starting-at-height-16187757;  ;  ;24674343
-    starting-at-height-16712757;  ;  ;23616348
-    starting-at-height-17237757;  ;  ;22603717
-    starting-at-height-17762757;  ;  ;21634507
-    starting-at-height-18287757;  ;  ;20706854
-    starting-at-height-18812757;  ;  ;19818978
-    starting-at-height-19337757;  ;  ;18969173
-    starting-at-height-19862757;  ;  ;18155805
-    starting-at-height-20387757;  ;  ;17377314
-    starting-at-height-20912757;  ;  ;16632203
-    starting-at-height-21437757;  ;  ;15919041
-    starting-at-height-21962757;  ;  ;15236459
-    starting-at-height-22487757;  ;  ;14583144
-    starting-at-height-23012757;  ;  ;13957843
-    starting-at-height-23537757;  ;  ;13359353
-    starting-at-height-24062757;  ;  ;12786526
-    starting-at-height-24587757;  ;  ;12238261
-    starting-at-height-25112757;  ;  ;11713504
-    starting-at-height-25637757;  ;  ;11211248
-    starting-at-height-26162757;  ;  ;10730528
-    starting-at-height-26687757;  ;  ;10270420
-    starting-at-height-27212757;  ;  ;9830041
-    starting-at-height-27737757;  ;  ;9408545
-    starting-at-height-28262757;  ;  ;9005122
-    starting-at-height-28787757;  ;  ;8618997
-    starting-at-height-29312757;  ;  ;8249428
-    starting-at-height-29837757;  ;  ;7895707
-    starting-at-height-30362757;  ;  ;7557151
-    starting-at-height-30887757;  ;  ;7233113
-    starting-at-height-31412757;  ;  ;6922969
-    starting-at-height-31937757;  ;  ;6626123
-    starting-at-height-32462757;  ;  ;6342006
-    starting-at-height-32987757;  ;  ;6070071
-    starting-at-height-33512757;  ;  ;5809796
-    starting-at-height-34037757;  ;  ;5560682
-    starting-at-height-34562757;  ;  ;5322249
-    starting-at-height-35087757;  ;  ;5094039
-    starting-at-height-35612757;  ;  ;4875615
-    starting-at-height-36137757;  ;  ;4666557
-    starting-at-height-36662757;  ;  ;4466462
-    starting-at-height-37187757;  ;  ;4274948
-    starting-at-height-37712757;  ;  ;4091645
-    starting-at-height-38237757;  ;  ;3916202
-    starting-at-height-38762757;  ;  ;3748282
-    starting-at-height-39287757;  ;  ;3587561
-    starting-at-height-39812757;  ;  ;3433732
-    starting-at-height-40337757;  ;  ;3286500
-    starting-at-height-40862757;  ;  ;3145580
-    starting-at-height-41387757;  ;  ;3010703
-    starting-at-height-41912757;  ;  ;2881608
-    starting-at-height-42437757;  ;  ;2758050
-    starting-at-height-42962757;  ;  ;2639789
-    starting-at-height-43487757;  ;  ;2526599
-    starting-at-height-44012757;  ;  ;2418263
-    starting-at-height-44537757;  ;  ;2314572
-    starting-at-height-45062757;  ;  ;2215326
-    starting-at-height-45587757;  ;  ;2120337
-    starting-at-height-46112757;  ;  ;2029420
-    starting-at-height-46637757;  ;  ;1942402
-    starting-at-height-47162757;  ;  ;1859115
-    starting-at-height-47687757;  ;  ;1779399
-    starting-at-height-48212757;  ;  ;1703101
-    starting-at-height-48737757;  ;  ;1630075
-    starting-at-height-49262757;  ;  ;1560180
-    starting-at-height-49787757;  ;  ;1493282
-    starting-at-height-50312757;  ;  ;1429253
-    starting-at-height-50837757;  ;  ;1367969
-    starting-at-height-51362757;  ;  ;1309312
-    starting-at-height-51887757;  ;  ;1253171
-    starting-at-height-52412757;  ;  ;1199437
-    starting-at-height-52937757;  ;  ;1148007
-    starting-at-height-53462757;  ;  ;1098783
-    starting-at-height-53987757;  ;  ;1051669
-    starting-at-height-54512757;  ;  ;1006575
-    starting-at-height-55037757;  ;  ;963414
-    starting-at-height-55562757;  ;  ;922105
-    starting-at-height-56087757;  ;  ;882566
-    starting-at-height-56612757;  ;  ;844723
-    starting-at-height-57137757;  ;  ;808503
-    starting-at-height-57662757;  ;  ;773836
-    starting-at-height-58187757;  ;  ;740655
-    starting-at-height-58712757;  ;  ;708897
-    starting-at-height-59237757;  ;  ;678500
-    starting-at-height-59762757;  ;  ;649407
-    starting-at-height-60287757;  ;  ;621562
-    starting-at-height-60812757;  ;  ;594910
-    starting-at-height-61337757;  ;  ;569401
-    starting-at-height-61862757;  ;  ;544986
-    starting-at-height-62387757;  ;  ;521618
-    starting-at-height-62912757;  ;  ;499252
-    starting-at-height-63437757;  ;  ;477845
-    starting-at-height-63962757;  ;  ;457356
-    starting-at-height-64487757;  ;  ;437745
-    starting-at-height-65012757;  ;  ;418975
-    starting-at-height-65537757;  ;  ;401010
-    starting-at-height-66062757;  ;  ;383816
-    starting-at-height-66587757;  ;  ;367358
-    starting-at-height-67112757;  ;  ;351606
-    starting-at-height-67637757;  ;  ;336530
-    starting-at-height-68162757;  ;  ;322100
-    starting-at-height-68687757;  ;  ;308289
-    starting-at-height-69212757;  ;  ;295070
-    starting-at-height-69737757;  ;  ;282418
-    starting-at-height-70262757;  ;  ;270308
-    starting-at-height-70787757;  ;  ;258718
-    starting-at-height-71312757;  ;  ;247624
-    starting-at-height-71837757;  ;  ;237007
-    starting-at-height-72362757;  ;  ;226844
-    starting-at-height-72887757;  ;  ;217118
-    starting-at-height-73412757;  ;  ;207808
-    starting-at-height-73937757;  ;  ;198897
-    starting-at-height-74462757;  ;  ;190369
-    starting-at-height-74987757;  ;  ;182206
-    starting-at-height-75512757;  ;  ;174394
-    starting-at-height-76037757;  ;  ;166916
-    starting-at-height-76562757;  ;  ;159759
-    starting-at-height-77087757;  ;  ;152908
-    starting-at-height-77612757;  ;  ;146352
-    starting-at-height-78137757;  ;  ;140077
-    starting-at-height-78662757;  ;  ;134070
-    starting-at-height-79187757;  ;  ;128322
-    starting-at-height-79712757;  ;  ;122819
-    starting-at-height-80237757;  ;  ;117553
-    starting-at-height-80762757;  ;  ;112513
-    starting-at-height-81287757;  ;  ;107688
-    starting-at-height-81812757;  ;  ;103071
-    starting-at-height-82337757;  ;  ;98651
-    starting-at-height-82862757;  ;  ;94421
-    starting-at-height-83387757;  ;  ;90372
-    starting-at-height-83912757;  ;  ;86497
-    starting-at-height-84437757;  ;  ;82789
-    starting-at-height-84962757;  ;  ;79239
-    starting-at-height-85487757;  ;  ;75841
-    starting-at-height-86012757;  ;  ;72589
-    starting-at-height-86537757;  ;  ;69477
-    starting-at-height-87062757;  ;  ;66498
-    starting-at-height-87587757;  ;  ;63646
-    starting-at-height-88112757;  ;  ;60917
-    starting-at-height-88637757;  ;  ;58305
-    starting-at-height-89162757;  ;  ;55805
-    starting-at-height-89687757;  ;  ;53412
-    starting-at-height-90212757;  ;  ;51122
-    starting-at-height-90737757;  ;  ;48930
-    starting-at-height-91262757;  ;  ;46832
-    starting-at-height-91787757;  ;  ;44824
-    starting-at-height-92312757;  ;  ;42902
-    starting-at-height-92837757;  ;  ;41062
-    starting-at-height-93362757;  ;  ;39301
-    starting-at-height-93887757;  ;  ;37616
-    starting-at-height-94412757;  ;  ;36003
-    starting-at-height-94937757;  ;  ;34460
-    starting-at-height-95462757;  ;  ;32982
-    starting-at-height-95987757;  ;  ;31568
-    starting-at-height-96512757;  ;  ;30214
-    starting-at-height-97037757;  ;  ;28919
-    starting-at-height-97562757;  ;  ;27679
-    starting-at-height-98087757;  ;  ;26492
-    starting-at-height-98612757;  ;  ;25356
-    starting-at-height-99137757;  ;  ;24269
-    starting-at-height-99662757;  ;  ;23228
-    starting-at-height-100187757;  ;  ;22232
-    starting-at-height-100712757;  ;  ;21279
-    starting-at-height-101237757;  ;  ;20366
-    starting-at-height-101762757;  ;  ;19493
-    starting-at-height-102287757;  ;  ;18657
-    starting-at-height-102812757;  ;  ;17857
-    starting-at-height-103337757;  ;  ;17091
-    starting-at-height-103862757;  ;  ;16358
-    starting-at-height-104387757;  ;  ;15657
-    starting-at-height-104912757;  ;  ;14986
-    starting-at-height-105437757;  ;  ;14343
-    starting-at-height-105962757;  ;  ;13728
-    starting-at-height-106487757;  ;  ;13139
-    starting-at-height-107012757;  ;  ;12576
-    starting-at-height-107537757;  ;  ;12037
-    starting-at-height-108062757;  ;  ;11521
-    starting-at-height-108587757;  ;  ;11027
-    starting-at-height-109112757;  ;  ;10554
-    starting-at-height-109637757;  ;  ;10101
-    starting-at-height-110162757;  ;  ;9668
-    starting-at-height-110687757;  ;  ;9254
-    starting-at-height-111212757;  ;  ;8857
-    starting-at-height-111737757;  ;  ;8477
-    starting-at-height-112262757;  ;  ;8113
-    starting-at-height-112787757;  ;  ;7766
-    starting-at-height-113312757;  ;  ;7433
-    starting-at-height-113837757;  ;  ;7114
-    starting-at-height-114362757;  ;  ;6809
-    starting-at-height-114887757;  ;  ;6517
-    starting-at-height-115412757;  ;  ;6237
-    starting-at-height-115937757;  ;  ;5970
-    starting-at-height-116462757;  ;  ;5714
-    starting-at-height-116987757;  ;  ;5469
-    starting-at-height-117512757;  ;  ;5234
-    starting-at-height-118037757;  ;  ;5010
-    starting-at-height-118562757;  ;  ;4795
-    starting-at-height-119087757;  ;  ;4589
-    starting-at-height-119612757;  ;  ;4393
-    starting-at-height-120137757;  ;  ;4204
-    starting-at-height-120662757;  ;  ;4024
-    starting-at-height-121187757;  ;  ;3851
-    starting-at-height-121712757;  ;  ;3686
-    starting-at-height-122237757;  ;  ;3528
-    starting-at-height-122762757;  ;  ;3377
-    starting-at-height-123287757;  ;  ;3232
-    starting-at-height-123812757;  ;  ;3093
-    starting-at-height-124337757;  ;  ;2961
-    starting-at-height-124862757;  ;  ;2834
-    starting-at-height-125387757;  ;  ;2712
-    starting-at-height-125912757;  ;  ;2596
-    starting-at-height-126437757;  ;  ;2485
-    starting-at-height-126962757;  ;  ;2378
-    starting-at-height-127487757;  ;  ;2276
-    starting-at-height-128012757;  ;  ;2178
-    starting-at-height-128537757;  ;  ;2085
-    starting-at-height-129062757;  ;  ;1996
-    starting-at-height-129587757;  ;  ;1910
-    starting-at-height-130112757;  ;  ;1828
-    starting-at-height-130637757;  ;  ;1750
-    starting-at-height-131162757;  ;  ;1675
-    starting-at-height-131687757;  ;  ;1603
-    starting-at-height-132212757;  ;  ;1534
-    starting-at-height-132737757;  ;  ;1468
-    starting-at-height-133262757;  ;  ;1405
-    starting-at-height-133787757;  ;  ;1345
-    starting-at-height-134312757;  ;  ;1287
-    starting-at-height-134837757;  ;  ;1232
-    starting-at-height-135362757;  ;  ;1179
-    starting-at-height-135887757;  ;  ;1129
-    starting-at-height-136412757;  ;  ;1080
-    starting-at-height-136937757;  ;  ;1034
-    starting-at-height-137462757;  ;  ;990
-    starting-at-height-137987757;  ;  ;947
-    starting-at-height-138512757;  ;  ;907
-    starting-at-height-139037757;  ;  ;868
-    starting-at-height-139562757;  ;  ;830
-    starting-at-height-140087757;  ;  ;795
-    starting-at-height-140612757;  ;  ;761
-    starting-at-height-141137757;  ;  ;728
-    starting-at-height-141662757;  ;  ;697
-    starting-at-height-142187757;  ;  ;667
-    starting-at-height-142712757;  ;  ;638
-    starting-at-height-143237757;  ;  ;611
-    starting-at-height-143762757;  ;  ;585
-    starting-at-height-144287757;  ;  ;560
-    starting-at-height-144812757;  ;  ;536
-    starting-at-height-145337757;  ;  ;513
-    starting-at-height-145862757;  ;  ;491
-    starting-at-height-146387757;  ;  ;470
-    starting-at-height-146912757;  ;  ;449
-    starting-at-height-147437757;  ;  ;430
-    starting-at-height-147962757;  ;  ;412
-    starting-at-height-148487757;  ;  ;394
-    starting-at-height-149012757;  ;  ;377
-    starting-at-height-149537757;  ;  ;361
-    starting-at-height-150062757;  ;  ;345
-    starting-at-height-150587757;  ;  ;331
-    starting-at-height-151112757;  ;  ;316
-    starting-at-height-151637757;  ;  ;303
-    starting-at-height-152162757;  ;  ;290
-    starting-at-height-152687757;  ;  ;277
-    starting-at-height-153212757;  ;  ;265
-    starting-at-height-153737757;  ;  ;254
-    starting-at-height-154262757;  ;  ;243
-    starting-at-height-154787757;  ;  ;233
-    starting-at-height-155312757;  ;  ;223
-    starting-at-height-155837757;  ;  ;213
-    starting-at-height-156362757;  ;  ;204
-    starting-at-height-156887757;  ;  ;195
-    starting-at-height-157412757;  ;  ;187
-    starting-at-height-157937757;  ;  ;179
-    starting-at-height-158462757;  ;  ;171
-    starting-at-height-158987757;  ;  ;164
-    starting-at-height-159512757;  ;  ;157
-    starting-at-height-160037757;  ;  ;150
-    starting-at-height-160562757;  ;  ;143
-    starting-at-height-161087757;  ;  ;137
-    starting-at-height-161612757;  ;  ;131
-    starting-at-height-162137757;  ;  ;126
-    starting-at-height-162662757;  ;  ;120
-    starting-at-height-163187757;  ;  ;115
-    starting-at-height-163712757;  ;  ;110
-    starting-at-height-164237757;  ;  ;105
-    starting-at-height-164762757;  ;  ;101
-    starting-at-height-165287757;  ;  ;97
-    starting-at-height-165812757;  ;  ;92
-    starting-at-height-166337757;  ;  ;88
-    starting-at-height-166862757;  ;  ;85
-    starting-at-height-167387757;  ;  ;81
-    starting-at-height-167912757;  ;  ;77
-    starting-at-height-168437757;  ;  ;74
-    starting-at-height-168962757;  ;  ;71
-    starting-at-height-169487757;  ;  ;68
-    starting-at-height-170012757;  ;  ;65
-    starting-at-height-170537757;  ;  ;62
-    starting-at-height-171062757;  ;  ;59
-    starting-at-height-171587757;  ;  ;57
-    starting-at-height-172112757;  ;  ;54
-    starting-at-height-172637757;  ;  ;52
-    starting-at-height-173162757;  ;  ;50
-    starting-at-height-173687757;  ;  ;48
-    starting-at-height-174212757;  ;  ;46
-    starting-at-height-174737757;  ;  ;44
-    starting-at-height-175262757;  ;  ;42
-    starting-at-height-175787757;  ;  ;40
-    starting-at-height-176312757;  ;  ;38
-    starting-at-height-176837757;  ;  ;37
-    starting-at-height-177362757;  ;  ;35
-    starting-at-height-177887757;  ;  ;33
-    starting-at-height-178412757;  ;  ;32
-    starting-at-height-178937757;  ;  ;31
-    starting-at-height-179462757;  ;  ;29
-    starting-at-height-179987757;  ;  ;28
-    starting-at-height-180512757;  ;  ;27
-    starting-at-height-181037757;  ;  ;26
-    starting-at-height-181562757;  ;  ;24
-    starting-at-height-182087757;  ;  ;23
-    starting-at-height-182612757;  ;  ;22
-    starting-at-height-183137757;  ;  ;21
-    starting-at-height-183662757;  ;  ;20
-    starting-at-height-184187757;  ;  ;20
-    starting-at-height-184712757;  ;  ;19
-    starting-at-height-185237757;  ;  ;18
-    starting-at-height-185762757;  ;  ;17
-    starting-at-height-186287757;  ;  ;16
-    starting-at-height-186812757;  ;  ;16
-    starting-at-height-187337757;  ;  ;15
-    starting-at-height-187862757;  ;  ;14
-    starting-at-height-188387757;  ;  ;14
-    starting-at-height-188912757;  ;  ;13
-    starting-at-height-189437757;  ;  ;12
-    starting-at-height-189962757;  ;  ;12
-    starting-at-height-190487757;  ;  ;11
-    starting-at-height-191012757;  ;  ;11
-    starting-at-height-191537757;  ;  ;10
-    starting-at-height-192062757;  ;  ;10
-    starting-at-height-192587757;  ;  ;9
-    starting-at-height-193112757;  ;  ;9
-    starting-at-height-193637757;  ;  ;9
-    starting-at-height-194162757;  ;  ;8
-    starting-at-height-194687757;  ;  ;8
-    starting-at-height-195212757;  ;  ;8
-    starting-at-height-195737757;  ;  ;7
-    starting-at-height-196262757;  ;  ;7
-    starting-at-height-196787757;  ;  ;7
-    starting-at-height-197312757;  ;  ;6
-    starting-at-height-197837757;  ;  ;6
-    starting-at-height-198362757;  ;  ;6
-    starting-at-height-198887757;  ;  ;5
-    starting-at-height-199412757;  ;  ;5
-    starting-at-height-199937757;  ;  ;5
-    starting-at-height-200462757;  ;  ;5
-    starting-at-height-200987757;  ;  ;4
-    starting-at-height-201512757;  ;  ;4
-    starting-at-height-202037757;  ;  ;4
-    starting-at-height-202562757;  ;  ;4
-    starting-at-height-203087757;  ;  ;4
-    starting-at-height-203612757;  ;  ;4
-    starting-at-height-204137757;  ;  ;3
-    starting-at-height-204662757;  ;  ;3
-    starting-at-height-205187757;  ;  ;3
-    starting-at-height-205712757;  ;  ;3
-    starting-at-height-206237757;  ;  ;3
-    starting-at-height-206762757;  ;  ;3
-    starting-at-height-207287757;  ;  ;2
-    starting-at-height-207812757;  ;  ;2
-    starting-at-height-208337757;  ;  ;2
-    starting-at-height-208862757;  ;  ;2
-    starting-at-height-209387757;  ;  ;2
-    starting-at-height-209912757;  ;  ;2
-    starting-at-height-210437757;  ;  ;2
-    starting-at-height-210962757;  ;  ;2
-    starting-at-height-211487757;  ;  ;2
-    starting-at-height-212012757;  ;  ;2
-    starting-at-height-212537757;  ;  ;1
-    starting-at-height-213062757;  ;  ;1
-    starting-at-height-213587757;  ;  ;1
-    starting-at-height-214112757;  ;  ;1
-    starting-at-height-214637757;  ;  ;1
-    starting-at-height-215162757;  ;  ;1
-    starting-at-height-215687757;  ;  ;1
-    starting-at-height-216212757;  ;  ;1
-    starting-at-height-216737757;  ;  ;1
-    starting-at-height-217262757;  ;  ;1
-    starting-at-height-217787757;  ;  ;1
-    starting-at-height-218312757;  ;  ;1
-    starting-at-height-218837757;  ;  ;1
-    starting-at-height-219362757;  ;  ;1
-    starting-at-height-219887757;  ;  ;1
-    starting-at-height-220412757;  ;  ;1
-    starting-at-height-220937757;  ;  ;0
+    **inflation**;
+    starting-at-height-2; 95998521
+    starting-at-height-200; 91882261
+    starting-at-height-400; 87942499
+    starting-at-height-600; 84171668
+    starting-at-height-800; 80562525
+    starting-at-height-2537757; 77108135
+    starting-at-height-3062757; 73801864
+    starting-at-height-3587757; 70637360
+    starting-at-height-4112757; 67608545
+    starting-at-height-4637757; 64709601
+    starting-at-height-5162757; 61934959
+    starting-at-height-5687757; 59279289
+    starting-at-height-6212757; 56737489
+    starting-at-height-6737757; 54304678
+    starting-at-height-7262757; 51976182
+    starting-at-height-7787757; 49747528
+    starting-at-height-8312757; 47614435
+    starting-at-height-8837757; 45572806
+    starting-at-height-9362757; 43618718
+    starting-at-height-9887757; 41748419
+    starting-at-height-10412757; 39958315
+    starting-at-height-10937757; 38244967
+    starting-at-height-11462757; 36605085
+    starting-at-height-11987757; 35035519
+    starting-at-height-12512757; 33533253
+    starting-at-height-13037757; 32095402
+    starting-at-height-13562757; 30719203
+    starting-at-height-14087757; 29402014
+    starting-at-height-14612757; 28141304
+    starting-at-height-15137757; 26934650
+    starting-at-height-15662757; 25779736
+    starting-at-height-16187757; 24674343
+    starting-at-height-16712757; 23616348
+    starting-at-height-17237757; 22603717
+    starting-at-height-17762757; 21634507
+    starting-at-height-18287757; 20706854
+    starting-at-height-18812757; 19818978
+    starting-at-height-19337757; 18969173
+    starting-at-height-19862757; 18155805
+    starting-at-height-20387757; 17377314
+    starting-at-height-20912757; 16632203
+    starting-at-height-21437757; 15919041
+    starting-at-height-21962757; 15236459
+    starting-at-height-22487757; 14583144
+    starting-at-height-23012757; 13957843
+    starting-at-height-23537757; 13359353
+    starting-at-height-24062757; 12786526
+    starting-at-height-24587757; 12238261
+    starting-at-height-25112757; 11713504
+    starting-at-height-25637757; 11211248
+    starting-at-height-26162757; 10730528
+    starting-at-height-26687757; 10270420
+    starting-at-height-27212757; 9830041
+    starting-at-height-27737757; 9408545
+    starting-at-height-28262757; 9005122
+    starting-at-height-28787757; 8618997
+    starting-at-height-29312757; 8249428
+    starting-at-height-29837757; 7895707
+    starting-at-height-30362757; 7557151
+    starting-at-height-30887757; 7233113
+    starting-at-height-31412757; 6922969
+    starting-at-height-31937757; 6626123
+    starting-at-height-32462757; 6342006
+    starting-at-height-32987757; 6070071
+    starting-at-height-33512757; 5809796
+    starting-at-height-34037757; 5560682
+    starting-at-height-34562757; 5322249
+    starting-at-height-35087757; 5094039
+    starting-at-height-35612757; 4875615
+    starting-at-height-36137757; 4666557
+    starting-at-height-36662757; 4466462
+    starting-at-height-37187757; 4274948
+    starting-at-height-37712757; 4091645
+    starting-at-height-38237757; 3916202
+    starting-at-height-38762757; 3748282
+    starting-at-height-39287757; 3587561
+    starting-at-height-39812757; 3433732
+    starting-at-height-40337757; 3286500
+    starting-at-height-40862757; 3145580
+    starting-at-height-41387757; 3010703
+    starting-at-height-41912757; 2881608
+    starting-at-height-42437757; 2758050
+    starting-at-height-42962757; 2639789
+    starting-at-height-43487757; 2526599
+    starting-at-height-44012757; 2418263
+    starting-at-height-44537757; 2314572
+    starting-at-height-45062757; 2215326
+    starting-at-height-45587757; 2120337
+    starting-at-height-46112757; 2029420
+    starting-at-height-46637757; 1942402
+    starting-at-height-47162757; 1859115
+    starting-at-height-47687757; 1779399
+    starting-at-height-48212757; 1703101
+    starting-at-height-48737757; 1630075
+    starting-at-height-49262757; 1560180
+    starting-at-height-49787757; 1493282
+    starting-at-height-50312757; 1429253
+    starting-at-height-50837757; 1367969
+    starting-at-height-51362757; 1309312
+    starting-at-height-51887757; 1253171
+    starting-at-height-52412757; 1199437
+    starting-at-height-52937757; 1148007
+    starting-at-height-53462757; 1098783
+    starting-at-height-53987757; 1051669
+    starting-at-height-54512757; 1006575
+    starting-at-height-55037757; 963414
+    starting-at-height-55562757; 922105
+    starting-at-height-56087757; 882566
+    starting-at-height-56612757; 844723
+    starting-at-height-57137757; 808503
+    starting-at-height-57662757; 773836
+    starting-at-height-58187757; 740655
+    starting-at-height-58712757; 708897
+    starting-at-height-59237757; 678500
+    starting-at-height-59762757; 649407
+    starting-at-height-60287757; 621562
+    starting-at-height-60812757; 594910
+    starting-at-height-61337757; 569401
+    starting-at-height-61862757; 544986
+    starting-at-height-62387757; 521618
+    starting-at-height-62912757; 499252
+    starting-at-height-63437757; 477845
+    starting-at-height-63962757; 457356
+    starting-at-height-64487757; 437745
+    starting-at-height-65012757; 418975
+    starting-at-height-65537757; 401010
+    starting-at-height-66062757; 383816
+    starting-at-height-66587757; 367358
+    starting-at-height-67112757; 351606
+    starting-at-height-67637757; 336530
+    starting-at-height-68162757; 322100
+    starting-at-height-68687757; 308289
+    starting-at-height-69212757; 295070
+    starting-at-height-69737757; 282418
+    starting-at-height-70262757; 270308
+    starting-at-height-70787757; 258718
+    starting-at-height-71312757; 247624
+    starting-at-height-71837757; 237007
+    starting-at-height-72362757; 226844
+    starting-at-height-72887757; 217118
+    starting-at-height-73412757; 207808
+    starting-at-height-73937757; 198897
+    starting-at-height-74462757; 190369
+    starting-at-height-74987757; 182206
+    starting-at-height-75512757; 174394
+    starting-at-height-76037757; 166916
+    starting-at-height-76562757; 159759
+    starting-at-height-77087757; 152908
+    starting-at-height-77612757; 146352
+    starting-at-height-78137757; 140077
+    starting-at-height-78662757; 134070
+    starting-at-height-79187757; 128322
+    starting-at-height-79712757; 122819
+    starting-at-height-80237757; 117553
+    starting-at-height-80762757; 112513
+    starting-at-height-81287757; 107688
+    starting-at-height-81812757; 103071
+    starting-at-height-82337757; 98651
+    starting-at-height-82862757; 94421
+    starting-at-height-83387757; 90372
+    starting-at-height-83912757; 86497
+    starting-at-height-84437757; 82789
+    starting-at-height-84962757; 79239
+    starting-at-height-85487757; 75841
+    starting-at-height-86012757; 72589
+    starting-at-height-86537757; 69477
+    starting-at-height-87062757; 66498
+    starting-at-height-87587757; 63646
+    starting-at-height-88112757; 60917
+    starting-at-height-88637757; 58305
+    starting-at-height-89162757; 55805
+    starting-at-height-89687757; 53412
+    starting-at-height-90212757; 51122
+    starting-at-height-90737757; 48930
+    starting-at-height-91262757; 46832
+    starting-at-height-91787757; 44824
+    starting-at-height-92312757; 42902
+    starting-at-height-92837757; 41062
+    starting-at-height-93362757; 39301
+    starting-at-height-93887757; 37616
+    starting-at-height-94412757; 36003
+    starting-at-height-94937757; 34460
+    starting-at-height-95462757; 32982
+    starting-at-height-95987757; 31568
+    starting-at-height-96512757; 30214
+    starting-at-height-97037757; 28919
+    starting-at-height-97562757; 27679
+    starting-at-height-98087757; 26492
+    starting-at-height-98612757; 25356
+    starting-at-height-99137757; 24269
+    starting-at-height-99662757; 23228
+    starting-at-height-100187757; 22232
+    starting-at-height-100712757; 21279
+    starting-at-height-101237757; 20366
+    starting-at-height-101762757; 19493
+    starting-at-height-102287757; 18657
+    starting-at-height-102812757; 17857
+    starting-at-height-103337757; 17091
+    starting-at-height-103862757; 16358
+    starting-at-height-104387757; 15657
+    starting-at-height-104912757; 14986
+    starting-at-height-105437757; 14343
+    starting-at-height-105962757; 13728
+    starting-at-height-106487757; 13139
+    starting-at-height-107012757; 12576
+    starting-at-height-107537757; 12037
+    starting-at-height-108062757; 11521
+    starting-at-height-108587757; 11027
+    starting-at-height-109112757; 10554
+    starting-at-height-109637757; 10101
+    starting-at-height-110162757; 9668
+    starting-at-height-110687757; 9254
+    starting-at-height-111212757; 8857
+    starting-at-height-111737757; 8477
+    starting-at-height-112262757; 8113
+    starting-at-height-112787757; 7766
+    starting-at-height-113312757; 7433
+    starting-at-height-113837757; 7114
+    starting-at-height-114362757; 6809
+    starting-at-height-114887757; 6517
+    starting-at-height-115412757; 6237
+    starting-at-height-115937757; 5970
+    starting-at-height-116462757; 5714
+    starting-at-height-116987757; 5469
+    starting-at-height-117512757; 5234
+    starting-at-height-118037757; 5010
+    starting-at-height-118562757; 4795
+    starting-at-height-119087757; 4589
+    starting-at-height-119612757; 4393
+    starting-at-height-120137757; 4204
+    starting-at-height-120662757; 4024
+    starting-at-height-121187757; 3851
+    starting-at-height-121712757; 3686
+    starting-at-height-122237757; 3528
+    starting-at-height-122762757; 3377
+    starting-at-height-123287757; 3232
+    starting-at-height-123812757; 3093
+    starting-at-height-124337757; 2961
+    starting-at-height-124862757; 2834
+    starting-at-height-125387757; 2712
+    starting-at-height-125912757; 2596
+    starting-at-height-126437757; 2485
+    starting-at-height-126962757; 2378
+    starting-at-height-127487757; 2276
+    starting-at-height-128012757; 2178
+    starting-at-height-128537757; 2085
+    starting-at-height-129062757; 1996
+    starting-at-height-129587757; 1910
+    starting-at-height-130112757; 1828
+    starting-at-height-130637757; 1750
+    starting-at-height-131162757; 1675
+    starting-at-height-131687757; 1603
+    starting-at-height-132212757; 1534
+    starting-at-height-132737757; 1468
+    starting-at-height-133262757; 1405
+    starting-at-height-133787757; 1345
+    starting-at-height-134312757; 1287
+    starting-at-height-134837757; 1232
+    starting-at-height-135362757; 1179
+    starting-at-height-135887757; 1129
+    starting-at-height-136412757; 1080
+    starting-at-height-136937757; 1034
+    starting-at-height-137462757; 990
+    starting-at-height-137987757; 947
+    starting-at-height-138512757; 907
+    starting-at-height-139037757; 868
+    starting-at-height-139562757; 830
+    starting-at-height-140087757; 795
+    starting-at-height-140612757; 761
+    starting-at-height-141137757; 728
+    starting-at-height-141662757; 697
+    starting-at-height-142187757; 667
+    starting-at-height-142712757; 638
+    starting-at-height-143237757; 611
+    starting-at-height-143762757; 585
+    starting-at-height-144287757; 560
+    starting-at-height-144812757; 536
+    starting-at-height-145337757; 513
+    starting-at-height-145862757; 491
+    starting-at-height-146387757; 470
+    starting-at-height-146912757; 449
+    starting-at-height-147437757; 430
+    starting-at-height-147962757; 412
+    starting-at-height-148487757; 394
+    starting-at-height-149012757; 377
+    starting-at-height-149537757; 361
+    starting-at-height-150062757; 345
+    starting-at-height-150587757; 331
+    starting-at-height-151112757; 316
+    starting-at-height-151637757; 303
+    starting-at-height-152162757; 290
+    starting-at-height-152687757; 277
+    starting-at-height-153212757; 265
+    starting-at-height-153737757; 254
+    starting-at-height-154262757; 243
+    starting-at-height-154787757; 233
+    starting-at-height-155312757; 223
+    starting-at-height-155837757; 213
+    starting-at-height-156362757; 204
+    starting-at-height-156887757; 195
+    starting-at-height-157412757; 187
+    starting-at-height-157937757; 179
+    starting-at-height-158462757; 171
+    starting-at-height-158987757; 164
+    starting-at-height-159512757; 157
+    starting-at-height-160037757; 150
+    starting-at-height-160562757; 143
+    starting-at-height-161087757; 137
+    starting-at-height-161612757; 131
+    starting-at-height-162137757; 126
+    starting-at-height-162662757; 120
+    starting-at-height-163187757; 115
+    starting-at-height-163712757; 110
+    starting-at-height-164237757; 105
+    starting-at-height-164762757; 101
+    starting-at-height-165287757; 97
+    starting-at-height-165812757; 92
+    starting-at-height-166337757; 88
+    starting-at-height-166862757; 85
+    starting-at-height-167387757; 81
+    starting-at-height-167912757; 77
+    starting-at-height-168437757; 74
+    starting-at-height-168962757; 71
+    starting-at-height-169487757; 68
+    starting-at-height-170012757; 65
+    starting-at-height-170537757; 62
+    starting-at-height-171062757; 59
+    starting-at-height-171587757; 57
+    starting-at-height-172112757; 54
+    starting-at-height-172637757; 52
+    starting-at-height-173162757; 50
+    starting-at-height-173687757; 48
+    starting-at-height-174212757; 46
+    starting-at-height-174737757; 44
+    starting-at-height-175262757; 42
+    starting-at-height-175787757; 40
+    starting-at-height-176312757; 38
+    starting-at-height-176837757; 37
+    starting-at-height-177362757; 35
+    starting-at-height-177887757; 33
+    starting-at-height-178412757; 32
+    starting-at-height-178937757; 31
+    starting-at-height-179462757; 29
+    starting-at-height-179987757; 28
+    starting-at-height-180512757; 27
+    starting-at-height-181037757; 26
+    starting-at-height-181562757; 24
+    starting-at-height-182087757; 23
+    starting-at-height-182612757; 22
+    starting-at-height-183137757; 21
+    starting-at-height-183662757; 20
+    starting-at-height-184187757; 20
+    starting-at-height-184712757; 19
+    starting-at-height-185237757; 18
+    starting-at-height-185762757; 17
+    starting-at-height-186287757; 16
+    starting-at-height-186812757; 16
+    starting-at-height-187337757; 15
+    starting-at-height-187862757; 14
+    starting-at-height-188387757; 14
+    starting-at-height-188912757; 13
+    starting-at-height-189437757; 12
+    starting-at-height-189962757; 12
+    starting-at-height-190487757; 11
+    starting-at-height-191012757; 11
+    starting-at-height-191537757; 10
+    starting-at-height-192062757; 10
+    starting-at-height-192587757; 9
+    starting-at-height-193112757; 9
+    starting-at-height-193637757; 9
+    starting-at-height-194162757; 8
+    starting-at-height-194687757; 8
+    starting-at-height-195212757; 8
+    starting-at-height-195737757; 7
+    starting-at-height-196262757; 7
+    starting-at-height-196787757; 7
+    starting-at-height-197312757; 6
+    starting-at-height-197837757; 6
+    starting-at-height-198362757; 6
+    starting-at-height-198887757; 5
+    starting-at-height-199412757; 5
+    starting-at-height-199937757; 5
+    starting-at-height-200462757; 5
+    starting-at-height-200987757; 4
+    starting-at-height-201512757; 4
+    starting-at-height-202037757; 4
+    starting-at-height-202562757; 4
+    starting-at-height-203087757; 4
+    starting-at-height-203612757; 4
+    starting-at-height-204137757; 3
+    starting-at-height-204662757; 3
+    starting-at-height-205187757; 3
+    starting-at-height-205712757; 3
+    starting-at-height-206237757; 3
+    starting-at-height-206762757; 3
+    starting-at-height-207287757; 2
+    starting-at-height-207812757; 2
+    starting-at-height-208337757; 2
+    starting-at-height-208862757; 2
+    starting-at-height-209387757; 2
+    starting-at-height-209912757; 2
+    starting-at-height-210437757; 2
+    starting-at-height-210962757; 2
+    starting-at-height-211487757; 2
+    starting-at-height-212012757; 2
+    starting-at-height-212537757; 1
+    starting-at-height-213062757; 1
+    starting-at-height-213587757; 1
+    starting-at-height-214112757; 1
+    starting-at-height-214637757; 1
+    starting-at-height-215162757; 1
+    starting-at-height-215687757; 1
+    starting-at-height-216212757; 1
+    starting-at-height-216737757; 1
+    starting-at-height-217262757; 1
+    starting-at-height-217787757; 1
+    starting-at-height-218312757; 1
+    starting-at-height-218837757; 1
+    starting-at-height-219362757; 1
+    starting-at-height-219887757; 1
+    starting-at-height-220412757; 1
+    starting-at-height-220937757; 0
 
 config-logging-broker.properties
 ================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **console**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    colorMode;  ;  ;Ansi
-    **console.component.levels**; ; ;
-    **file**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    directory;  ;  ;logs
-    filePattern;  ;  ;logs/catapult_broker%4N.log
-    rotationSize;  ;  ;25MB
-    maxTotalSize;  ;  ;2500MB
-    minFreeSpace;  ;  ;100MB
-    **file.component.levels**; ; ;
+    **console**;
+    sinkType; Async
+    level; Info
+    colorMode; Ansi
+    **console.component.levels**;
+    **file**;
+    sinkType; Async
+    level; Info
+    directory; logs
+    filePattern; logs/catapult_broker%4N.log
+    rotationSize; 25MB
+    maxTotalSize; 2500MB
+    minFreeSpace; 100MB
+    **file.component.levels**;
 
 config-logging-recovery.properties
 ==================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **console**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    colorMode;  ;  ;Ansi
-    **console.component.levels**; ; ;
-    **file**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    directory;  ;  ;logs
-    filePattern;  ;  ;logs/catapult_recovery%4N.log
-    rotationSize;  ;  ;25MB
-    maxTotalSize;  ;  ;2500MB
-    minFreeSpace;  ;  ;100MB
-    **file.component.levels**; ; ;
+    **console**;
+    sinkType; Async
+    level; Info
+    colorMode; Ansi
+    **console.component.levels**;
+    **file**;
+    sinkType; Async
+    level; Info
+    directory; logs
+    filePattern; logs/catapult_recovery%4N.log
+    rotationSize; 25MB
+    maxTotalSize; 2500MB
+    minFreeSpace; 100MB
+    **file.component.levels**;
 
 config-logging-server.properties
 ================================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **console**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    colorMode;  ;  ;Ansi
-    **console.component.levels**; ; ;
-    **file**; ; ;
-    sinkType;  ;  ;Async
-    level;  ;  ;Info
-    directory;  ;  ;logs
-    filePattern;  ;  ;logs/catapult_server%4N.log
-    rotationSize;  ;  ;25MB
-    maxTotalSize;  ;  ;2500MB
-    minFreeSpace;  ;  ;100MB
-    **file.component.levels**; ; ;
+    **console**;
+    sinkType; Async
+    level; Info
+    colorMode; Ansi
+    **console.component.levels**;
+    **file**;
+    sinkType; Async
+    level; Info
+    directory; logs
+    filePattern; logs/catapult_server%4N.log
+    rotationSize; 25MB
+    maxTotalSize; 2500MB
+    minFreeSpace; 100MB
+    **file.component.levels**;
 
 config-messaging.properties
 ===========================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **messaging**; ; ;
-    subscriberPort;  ;  ;7902
+    **messaging**;
+    subscriberPort; 7902
 
 config-network.properties
 =========================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value", "Type", "Description"
     :delim: ;
 
     **network**; ; ;
-    identifier; NetworkIdentifier ; Network identifier. ;public-test
-    nemesisSignerPublicKey; Key ; Nemesis public key. ;78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0
-    nodeEqualityStrategy; NodeIdentityEqualityStrategy ; Node equality strategy. ;host
-    generationHashSeed;  ;  ;6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD
-    epochAdjustment; utils::TimeSpan ; Nemesis epoch time adjustment. ;1573430400s
+    identifier; public-test; NetworkIdentifier; Network identifier.
+    nemesisSignerPublicKey; 78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0; Key; Nemesis public key.
+    nodeEqualityStrategy; host; NodeIdentityEqualityStrategy; Node equality strategy.
+    generationHashSeed; 6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD; ;
+    epochAdjustment; 1573430400s; utils::TimeSpan; Nemesis epoch time adjustment.
     **chain**; ; ;
-    enableVerifiableState; bool ; Set to true if block chain should calculate state hashes so that state is fully verifiable at each block. ;true
-    enableVerifiableReceipts; bool ; Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block. ;true
-    currencyMosaicId; MosaicId ; Mosaic id used as primary chain currency. ;0x5B66'E76B'ECAD'0860
-    harvestingMosaicId; MosaicId ; Mosaic id used to provide harvesting ability. ;0x5B66'E76B'ECAD'0860
-    blockGenerationTargetTime; utils::TimeSpan ; Targeted time between blocks. ;30s
-    blockTimeSmoothingFactor; uint32_t ; Note: A higher value makes the network more biased. Note: This can lower security because it will increase the influence of time relative to importance. ;3000
-    importanceGrouping; uint64_t ; Number of blocks that should be treated as a group for importance purposes. Note: Importances will only be calculated at blocks that are multiples of this grouping number. ;180
-    importanceActivityPercentage; uint8_t ; Percentage of importance resulting from fee generation and beneficiary usage. ;5
-    maxRollbackBlocks; uint32_t ; Maximum number of blocks that can be rolled back. ;0
-    maxDifficultyBlocks; uint32_t ; Maximum number of blocks to use in a difficulty calculation. ;60
-    defaultDynamicFeeMultiplier; BlockFeeMultiplier ; Default multiplier to use for dynamic fees. ;1'000
-    maxTransactionLifetime; utils::TimeSpan ; Maximum lifetime a transaction can have before it expires. ;6h
-    maxBlockFutureTime; utils::TimeSpan ; Maximum future time of a block that can be accepted. ;500ms
-    initialCurrencyAtomicUnits; Amount ; Initial currency atomic units available in the network. ;7'831'975'436'000'000
-    maxMosaicAtomicUnits; Amount ; Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network. ;9'000'000'000'000'000
-    totalChainImportance; Importance ; Total whole importance units available in the network. ;7'831'975'436'000'000
-    minHarvesterBalance; Amount ; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting. ;10'000'000'000
-    maxHarvesterBalance; Amount ; Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting. ;50'000'000'000'000
-    minVoterBalance; Amount ; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting. ;3'000'000'000'000
-    votingSetGrouping;  ;  ;720
-    maxVotingKeysPerAccount; uint8_t ; Maximum number of voting keys that can be registered at once per account. ;3
-    minVotingKeyLifetime; uint32_t ; Minimum number of finalization rounds for which voting key can be registered. ;28
-    maxVotingKeyLifetime; uint32_t ; Maximum number of finalization rounds for which voting key can be registered. ;26280
-    harvestBeneficiaryPercentage; uint8_t ; Percentage of the harvested fee that is collected by the beneficiary account. ;25
-    harvestNetworkPercentage; uint8_t ; Percentage of the harvested fee that is collected by the network. ;5
-    harvestNetworkFeeSinkAddress; Address ; Address of the harvest network fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
-    maxTransactionsPerBlock; uint32_t ; Maximum number of transactions per block. ;6'000
-    **plugin:catapult.plugins.accountlink**; ; ;
-    dummy;  ;  ;to trigger plugin load
+    enableVerifiableState; true; bool; Set to true if block chain should calculate state hashes so that state is fully verifiable at each block.
+    enableVerifiableReceipts; true; bool; Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block.
+    currencyMosaicId; 0x5B66'E76B'ECAD'0860; MosaicId; Mosaic id used as primary chain currency.
+    harvestingMosaicId; 0x5B66'E76B'ECAD'0860; MosaicId; Mosaic id used to provide harvesting ability.
+    blockGenerationTargetTime; 30s; utils::TimeSpan; Targeted time between blocks.
+    blockTimeSmoothingFactor; 3000; uint32_t; Note: A higher value makes the network more biased. Note: This can lower security because it will increase the influence of time relative to importance.
+    importanceGrouping; 180; uint64_t; Number of blocks that should be treated as a group for importance purposes. Note: Importances will only be calculated at blocks that are multiples of this grouping number.
+    importanceActivityPercentage; 5; uint8_t; Percentage of importance resulting from fee generation and beneficiary usage.
+    maxRollbackBlocks; 0; uint32_t; Maximum number of blocks that can be rolled back.
+    maxDifficultyBlocks; 60; uint32_t; Maximum number of blocks to use in a difficulty calculation.
+    defaultDynamicFeeMultiplier; 1'000; BlockFeeMultiplier; Default multiplier to use for dynamic fees.
+    maxTransactionLifetime; 6h; utils::TimeSpan; Maximum lifetime a transaction can have before it expires.
+    maxBlockFutureTime; 500ms; utils::TimeSpan; Maximum future time of a block that can be accepted.
+    initialCurrencyAtomicUnits; 7'831'975'436'000'000; Amount; Initial currency atomic units available in the network.
+    maxMosaicAtomicUnits; 9'000'000'000'000'000; Amount; Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network.
+    totalChainImportance; 7'831'975'436'000'000; Importance; Total whole importance units available in the network.
+    minHarvesterBalance; 10'000'000'000; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+    maxHarvesterBalance; 50'000'000'000'000; Amount; Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.
+    minVoterBalance; 3'000'000'000'000; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting.
+    votingSetGrouping; 720; ;
+    maxVotingKeysPerAccount; 3; uint8_t; Maximum number of voting keys that can be registered at once per account.
+    minVotingKeyLifetime; 28; uint32_t; Minimum number of finalization rounds for which voting key can be registered.
+    maxVotingKeyLifetime; 26280; uint32_t; Maximum number of finalization rounds for which voting key can be registered.
+    harvestBeneficiaryPercentage; 25; uint8_t; Percentage of the harvested fee that is collected by the beneficiary account.
+    harvestNetworkPercentage; 5; uint8_t; Percentage of the harvested fee that is collected by the network.
+    harvestNetworkFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the harvest network fee sink account.
+    maxTransactionsPerBlock; 6'000; uint32_t; Maximum number of transactions per block.
+    **plugin:catapult.plugins.accountlink**;
+    dummy; to trigger plugin load
     **plugin:catapult.plugins.aggregate**; ; ;
-    maxTransactionsPerAggregate; uint32_t ; Maximum number of transactions per aggregate. ;100
-    maxCosignaturesPerAggregate; uint8_t ; Maximum number of cosignatures per aggregate. ;25
-    enableStrictCosignatureCheck; bool ; Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally. ;false
-    enableBondedAggregateSupport; bool ; Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected. ;true
-    maxBondedTransactionLifetime; utils::TimeSpan ; Maximum lifetime a bonded transaction can have before it expires. ;48h
+    maxTransactionsPerAggregate; 100; uint32_t; Maximum number of transactions per aggregate.
+    maxCosignaturesPerAggregate; 25; uint8_t; Maximum number of cosignatures per aggregate.
+    enableStrictCosignatureCheck; false; bool; Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally.
+    enableBondedAggregateSupport; true; bool; Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected.
+    maxBondedTransactionLifetime; 48h; utils::TimeSpan; Maximum lifetime a bonded transaction can have before it expires.
     **plugin:catapult.plugins.lockhash**; ; ;
-    lockedFundsPerAggregate; Amount ; Amount that has to be locked per aggregate in partial cache. ;10'000'000
-    maxHashLockDuration; utils::BlockSpan ; Maximum number of blocks for which a hash lock can exist. ;2d
+    lockedFundsPerAggregate; 10'000'000; Amount; Amount that has to be locked per aggregate in partial cache.
+    maxHashLockDuration; 2d; utils::BlockSpan; Maximum number of blocks for which a hash lock can exist.
     **plugin:catapult.plugins.locksecret**; ; ;
-    maxSecretLockDuration; utils::BlockSpan ; Maximum number of blocks for which a secret lock can exist. ;365d
-    minProofSize; uint16_t ; Minimum size of a proof in bytes. ;20
-    maxProofSize; uint16_t ; Maximum size of a proof in bytes. ;1024
+    maxSecretLockDuration; 365d; utils::BlockSpan; Maximum number of blocks for which a secret lock can exist.
+    minProofSize; 20; uint16_t; Minimum size of a proof in bytes.
+    maxProofSize; 1024; uint16_t; Maximum size of a proof in bytes.
     **plugin:catapult.plugins.metadata**; ; ;
-    maxValueSize; uint16_t ; Maximum metadata value size. ;1024
+    maxValueSize; 1024; uint16_t; Maximum metadata value size.
     **plugin:catapult.plugins.mosaic**; ; ;
-    maxMosaicsPerAccount; uint16_t ; Maximum number of mosaics that an account can own. ;1'000
-    maxMosaicDuration; utils::BlockSpan ; Maximum mosaic duration. ;3650d
-    maxMosaicDivisibility; uint8_t ; Maximum mosaic divisibility. ;6
-    mosaicRentalFeeSinkAddress; Address ; Address of the mosaic rental fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
-    mosaicRentalFee; Amount ; Mosaic rental fee. ;500
+    maxMosaicsPerAccount; 1'000; uint16_t; Maximum number of mosaics that an account can own.
+    maxMosaicDuration; 3650d; utils::BlockSpan; Maximum mosaic duration.
+    maxMosaicDivisibility; 6; uint8_t; Maximum mosaic divisibility.
+    mosaicRentalFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the mosaic rental fee sink account.
+    mosaicRentalFee; 500; Amount; Mosaic rental fee.
     **plugin:catapult.plugins.multisig**; ; ;
-    maxMultisigDepth; uint8_t ; Maximum number of multisig levels. ;3
-    maxCosignatoriesPerAccount; uint32_t ; Maximum number of cosignatories per account. ;25
-    maxCosignedAccountsPerAccount; uint32_t ; Maximum number of accounts a single account can cosign. ;25
+    maxMultisigDepth; 3; uint8_t; Maximum number of multisig levels.
+    maxCosignatoriesPerAccount; 25; uint32_t; Maximum number of cosignatories per account.
+    maxCosignedAccountsPerAccount; 25; uint32_t; Maximum number of accounts a single account can cosign.
     **plugin:catapult.plugins.namespace**; ; ;
-    maxNameSize; uint8_t ; Maximum namespace name size. ;64
-    maxChildNamespaces; uint16_t ; Maximum number of children for a root namespace. ;256
-    maxNamespaceDepth; uint8_t ; Maximum namespace depth. ;3
-    minNamespaceDuration; utils::BlockSpan ; Minimum namespace duration. ;30d
-    maxNamespaceDuration; utils::BlockSpan ; Maximum namespace duration. ;1825d
-    namespaceGracePeriodDuration; utils::BlockSpan ; Grace period during which time only the previous owner can renew an expired namespace. ;1d
-    reservedRootNamespaceNames; unordered_set<string> ; Reserved root namespaces that cannot be claimed. ;symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info
-    namespaceRentalFeeSinkAddress; Address ; Address of the namespace rental fee sink account. ;TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q
-    rootNamespaceRentalFeePerBlock; Amount ; Root namespace rental fee per block. ;1
-    childNamespaceRentalFee; Amount ; Child namespace rental fee. ;100
+    maxNameSize; 64; uint8_t; Maximum namespace name size.
+    maxChildNamespaces; 256; uint16_t; Maximum number of children for a root namespace.
+    maxNamespaceDepth; 3; uint8_t; Maximum namespace depth.
+    minNamespaceDuration; 30d; utils::BlockSpan; Minimum namespace duration.
+    maxNamespaceDuration; 1825d; utils::BlockSpan; Maximum namespace duration.
+    namespaceGracePeriodDuration; 1d; utils::BlockSpan; Grace period during which time only the previous owner can renew an expired namespace.
+    reservedRootNamespaceNames; symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info; unordered_set<string>; Reserved root namespaces that cannot be claimed.
+    namespaceRentalFeeSinkAddress; TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q; Address; Address of the namespace rental fee sink account.
+    rootNamespaceRentalFeePerBlock; 1; Amount; Root namespace rental fee per block.
+    childNamespaceRentalFee; 100; Amount; Child namespace rental fee.
     **plugin:catapult.plugins.restrictionaccount**; ; ;
-    maxAccountRestrictionValues; uint16_t ; Maximum number of account restriction values. ;512
+    maxAccountRestrictionValues; 512; uint16_t; Maximum number of account restriction values.
     **plugin:catapult.plugins.restrictionmosaic**; ; ;
-    maxMosaicRestrictionValues; uint8_t ; Maximum number of mosaic restriction values. ;20
+    maxMosaicRestrictionValues; 20; uint8_t; Maximum number of mosaic restriction values.
     **plugin:catapult.plugins.transfer**; ; ;
-    maxMessageSize; uint16_t ; Maximum transaction message size. ;1024
+    maxMessageSize; 1024; uint16_t; Maximum transaction message size.
 
 config-networkheight.properties
 ===============================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **networkheight**; ; ;
-    maxNodes;  ;  ;5
+    **networkheight**;
+    maxNodes; 5
 
 config-node.properties
 ======================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value", "Type", "Description"
     :delim: ;
 
     **node**; ; ;
-    port; unsigned short ; Server port. ;7900
-    maxIncomingConnectionsPerIdentity; uint32_t ; Maximum number of incoming connections per identity over primary port. ;6
-    enableAddressReuse; bool ; Set to true if the server should reuse ports already in use. ;false
-    enableSingleThreadPool; bool ; Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used. ;false
-    enableCacheDatabaseStorage; bool ; Set to true if cache data should be saved in a database. ;true
-    enableAutoSyncCleanup; bool ; Set to true if temporary sync files should be automatically cleaned up. Note: This should be Set to false if broker process is running. ;false
-    enableTransactionSpamThrottling; bool ; Set to true if transaction spam throttling should be enabled. ;true
-    transactionSpamThrottlingMaxBoostFee; Amount ; Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled. ;10'000'000
-    maxHashesPerSyncAttempt;  ;  ;610
-    maxBlocksPerSyncAttempt; uint32_t ; Maximum number of blocks per sync attempt. ;602
-    maxChainBytesPerSyncAttempt; utils::FileSize ; Maximum chain bytes per sync attempt. ;100MB
-    shortLivedCacheTransactionDuration; utils::TimeSpan ; Duration of a transaction in the short lived cache. ;10m
-    shortLivedCacheBlockDuration; utils::TimeSpan ; Duration of a block in the short lived cache. ;100m
-    shortLivedCachePruneInterval; utils::TimeSpan ; Time between short lived cache pruning. ;90s
-    shortLivedCacheMaxSize; uint32_t ; Maximum size of a short lived cache. ;200'000
-    minFeeMultiplier; BlockFeeMultiplier ; Minimum fee multiplier of transactions to propagate and include in blocks. ;100
-    transactionSelectionStrategy; model::TransactionSelectionStrategy ; Transaction selection strategy used for syncing and harvesting unconfirmed transactions. ;maximize-fee
-    unconfirmedTransactionsCacheMaxResponseSize; utils::FileSize ; Maximum size of an unconfirmed transactions response. ;20MB
-    unconfirmedTransactionsCacheMaxSize; uint32_t ; Maximum size of the unconfirmed transactions cache. ;50'000
-    connectTimeout; utils::TimeSpan ; Timeout for connecting to a peer. ;15s
-    syncTimeout; utils::TimeSpan ; Timeout for syncing with a peer. ;120s
-    socketWorkingBufferSize; utils::FileSize ; Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size). ;512KB
-    socketWorkingBufferSensitivity; uint32_t ; Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). Note: Set to 0 will disable memory reclamation. ;100
-    maxPacketDataSize; utils::FileSize ; Maximum packet data size. ;150MB
-    blockDisruptorSize; uint32_t ; Size of the block disruptor circular buffer. ;4096
-    blockElementTraceInterval; uint32_t ; Multiple of elements at which a block element should be traced through queue and completion. ;1
-    transactionDisruptorSize; uint32_t ; Size of the transaction disruptor circular buffer. ;16384
-    transactionElementTraceInterval; uint32_t ; Multiple of elements at which a transaction element should be traced through queue and completion. ;10
-    enableDispatcherAbortWhenFull; bool ; Set to true if the process should terminate when any dispatcher is full. ;false
-    enableDispatcherInputAuditing; bool ; Set to true if all dispatcher inputs should be audited. ;false
-    maxCacheDatabaseWriteBatchSize; utils::FileSize ; Maximum cache database write batch size. ;5MB
-    maxTrackedNodes; uint32_t ; Maximum number of nodes to track in memory. ;5'000
-    trustedHosts; unordered_set<string> ; Trusted hosts that are allowed to execute protected API calls on this node. ;
-    localNetworks; unordered_set<string> ; Networks that should be treated as local. ;127.0.0.1, 172.20.0.25
+    port; 7900; unsigned short; Server port.
+    maxIncomingConnectionsPerIdentity; 6; uint32_t; Maximum number of incoming connections per identity over primary port.
+    enableAddressReuse; false; bool; Set to true if the server should reuse ports already in use.
+    enableSingleThreadPool; false; bool; Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used.
+    enableCacheDatabaseStorage; true; bool; Set to true if cache data should be saved in a database.
+    enableAutoSyncCleanup; false; bool; Set to true if temporary sync files should be automatically cleaned up. Note: This should be Set to false if broker process is running.
+    enableTransactionSpamThrottling; true; bool; Set to true if transaction spam throttling should be enabled.
+    transactionSpamThrottlingMaxBoostFee; 10'000'000; Amount; Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled.
+    maxHashesPerSyncAttempt; 610; ;
+    maxBlocksPerSyncAttempt; 602; uint32_t; Maximum number of blocks per sync attempt.
+    maxChainBytesPerSyncAttempt; 100MB; utils::FileSize; Maximum chain bytes per sync attempt.
+    shortLivedCacheTransactionDuration; 10m; utils::TimeSpan; Duration of a transaction in the short lived cache.
+    shortLivedCacheBlockDuration; 100m; utils::TimeSpan; Duration of a block in the short lived cache.
+    shortLivedCachePruneInterval; 90s; utils::TimeSpan; Time between short lived cache pruning.
+    shortLivedCacheMaxSize; 200'000; uint32_t; Maximum size of a short lived cache.
+    minFeeMultiplier; 100; BlockFeeMultiplier; Minimum fee multiplier of transactions to propagate and include in blocks.
+    transactionSelectionStrategy; maximize-fee; model::TransactionSelectionStrategy; Transaction selection strategy used for syncing and harvesting unconfirmed transactions.
+    unconfirmedTransactionsCacheMaxResponseSize; 20MB; utils::FileSize; Maximum size of an unconfirmed transactions response.
+    unconfirmedTransactionsCacheMaxSize; 50'000; uint32_t; Maximum size of the unconfirmed transactions cache.
+    connectTimeout; 15s; utils::TimeSpan; Timeout for connecting to a peer.
+    syncTimeout; 120s; utils::TimeSpan; Timeout for syncing with a peer.
+    socketWorkingBufferSize; 512KB; utils::FileSize; Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size).
+    socketWorkingBufferSensitivity; 100; uint32_t; Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). Note: Set to 0 will disable memory reclamation.
+    maxPacketDataSize; 150MB; utils::FileSize; Maximum packet data size.
+    blockDisruptorSize; 4096; uint32_t; Size of the block disruptor circular buffer.
+    blockElementTraceInterval; 1; uint32_t; Multiple of elements at which a block element should be traced through queue and completion.
+    transactionDisruptorSize; 16384; uint32_t; Size of the transaction disruptor circular buffer.
+    transactionElementTraceInterval; 10; uint32_t; Multiple of elements at which a transaction element should be traced through queue and completion.
+    enableDispatcherAbortWhenFull; false; bool; Set to true if the process should terminate when any dispatcher is full.
+    enableDispatcherInputAuditing; false; bool; Set to true if all dispatcher inputs should be audited.
+    maxCacheDatabaseWriteBatchSize; 5MB; utils::FileSize; Maximum cache database write batch size.
+    maxTrackedNodes; 5'000; uint32_t; Maximum number of nodes to track in memory.
+    trustedHosts; ; unordered_set<string>; Trusted hosts that are allowed to execute protected API calls on this node.
+    localNetworks; 127.0.0.1, 172.20.0.25; unordered_set<string>; Networks that should be treated as local.
     **localnode**; ; ;
-    host; string ; Node host (leave empty to auto-detect IP). ;
-    friendlyName; string ; Node friendly name (leave empty to use address). ;myFriendlyName
-    version; uint32_t ; Node version. ;0
-    roles; ionet::NodeRoles ; Node roles. ;Api,Peer,Voting
+    host; ; string; Node host (leave empty to auto-detect IP).
+    friendlyName; myFriendlyName; string; Node friendly name (leave empty to use address).
+    version; 0; uint32_t; Node version.
+    roles; Api,Peer,Voting; ionet::NodeRoles; Node roles.
     **outgoing_connections**; ; ;
-    maxConnections; uint16_t ; Maximum number of active connections. ;10
-    maxConnectionAge; uint16_t ; Maximum connection age. ;200
-    maxConnectionBanAge; uint16_t ; Maximum connection ban age. ;20
-    numConsecutiveFailuresBeforeBanning; uint16_t ; Number of consecutive connection failures before a connection is banned. ;3
+    maxConnections; 10; uint16_t; Maximum number of active connections.
+    maxConnectionAge; 200; uint16_t; Maximum connection age.
+    maxConnectionBanAge; 20; uint16_t; Maximum connection ban age.
+    numConsecutiveFailuresBeforeBanning; 3; uint16_t; Number of consecutive connection failures before a connection is banned.
     **incoming_connections**; ; ;
-    maxConnections; uint16_t ; Maximum number of active connections. ;512
-    maxConnectionAge; uint16_t ; Maximum connection age. ;200
-    maxConnectionBanAge; uint16_t ; Maximum connection ban age. ;20
-    numConsecutiveFailuresBeforeBanning; uint16_t ; Number of consecutive connection failures before a connection is banned. ;3
-    backlogSize; uint16_t ; Maximum size of the pending connections queue. ;512
+    maxConnections; 512; uint16_t; Maximum number of active connections.
+    maxConnectionAge; 200; uint16_t; Maximum connection age.
+    maxConnectionBanAge; 20; uint16_t; Maximum connection ban age.
+    numConsecutiveFailuresBeforeBanning; 3; uint16_t; Number of consecutive connection failures before a connection is banned.
+    backlogSize; 512; uint16_t; Maximum size of the pending connections queue.
     **banning**; ; ;
-    defaultBanDuration; utils::TimeSpan ; Default duration for banning. ;12h
-    maxBanDuration; utils::TimeSpan ; Maximum duration for banning. ;12h
-    keepAliveDuration; utils::TimeSpan ; Duration to keep account in container after the ban expired. ;48h
-    maxBannedNodes; uint32_t ; Maximum number of banned nodes. ;5'000
-    numReadRateMonitoringBuckets; uint16_t ; Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring). ;4
-    readRateMonitoringBucketDuration; utils::TimeSpan ; Duration of each read rate monitoring bucket. ;15s
-    maxReadRateMonitoringTotalSize; utils::FileSize ; Maximum size allowed during full read rate monitoring period. ;100MB
+    defaultBanDuration; 12h; utils::TimeSpan; Default duration for banning.
+    maxBanDuration; 12h; utils::TimeSpan; Maximum duration for banning.
+    keepAliveDuration; 48h; utils::TimeSpan; Duration to keep account in container after the ban expired.
+    maxBannedNodes; 5'000; uint32_t; Maximum number of banned nodes.
+    numReadRateMonitoringBuckets; 4; uint16_t; Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring).
+    readRateMonitoringBucketDuration; 15s; utils::TimeSpan; Duration of each read rate monitoring bucket.
+    maxReadRateMonitoringTotalSize; 100MB; utils::FileSize; Maximum size allowed during full read rate monitoring period.
 
 config-pt.properties
 ====================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **partialtransactions**; ; ;
-    cacheMaxResponseSize;  ;  ;20MB
-    cacheMaxSize;  ;  ;1'000'000
+    **partialtransactions**;
+    cacheMaxResponseSize; 20MB
+    cacheMaxSize; 1'000'000
 
 config-task.properties
 ======================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **logging task**; ; ;
-    startDelay;  ;  ;1m
-    repeatDelay;  ;  ;10m
-    **connect peers task for service Finalization**; ; ;
-    startDelay;  ;  ;2s
-    repeatDelay;  ;  ;1m
-    **finalization task**; ; ;
-    startDelay;  ;  ;2m
-    repeatDelay;  ;  ;15s
-    **pull finalization messages task**; ; ;
-    startDelay;  ;  ;3s
-    repeatDelay;  ;  ;1s
-    **pull finalization proof task**; ; ;
-    startDelay;  ;  ;10s
-    repeatDelay;  ;  ;50s
-    **harvesting task**; ; ;
-    startDelay;  ;  ;30s
-    repeatDelay;  ;  ;1s
-    **network chain height detection**; ; ;
-    startDelay;  ;  ;1s
-    repeatDelay;  ;  ;15s
-    **node discovery peers task**; ; ;
-    startDelay;  ;  ;1m
-    minDelay;  ;  ;1m
-    maxDelay;  ;  ;10m
-    numPhaseOneRounds;  ;  ;10
-    numTransitionRounds;  ;  ;20
-    **node discovery ping task**; ; ;
-    startDelay;  ;  ;2m
-    repeatDelay;  ;  ;5m
-    **age peers task for service Readers**; ; ;
-    startDelay;  ;  ;1m
-    repeatDelay;  ;  ;1m
-    **batch partial transaction task**; ; ;
-    startDelay;  ;  ;500ms
-    repeatDelay;  ;  ;500ms
-    **connect peers task for service Pt**; ; ;
-    startDelay;  ;  ;3s
-    repeatDelay;  ;  ;1m
-    **pull partial transactions task**; ; ;
-    startDelay;  ;  ;10s
-    repeatDelay;  ;  ;3s
-    **batch transaction task**; ; ;
-    startDelay;  ;  ;500ms
-    repeatDelay;  ;  ;500ms
-    **connect peers task for service Sync**; ; ;
-    startDelay;  ;  ;1s
-    repeatDelay;  ;  ;1m
-    **pull unconfirmed transactions task**; ; ;
-    startDelay;  ;  ;4s
-    repeatDelay;  ;  ;3s
-    **synchronizer task**; ; ;
-    startDelay;  ;  ;3s
-    repeatDelay;  ;  ;3s
-    **time synchronization task**; ; ;
-    startDelay;  ;  ;1m
-    minDelay;  ;  ;3m
-    maxDelay;  ;  ;180m
-    numPhaseOneRounds;  ;  ;5
-    numTransitionRounds;  ;  ;10
-    **static node refresh task**; ; ;
-    startDelay;  ;  ;5ms
-    minDelay;  ;  ;15s
-    maxDelay;  ;  ;24h
-    numPhaseOneRounds;  ;  ;20
-    numTransitionRounds;  ;  ;20
+    **logging task**;
+    startDelay; 1m
+    repeatDelay; 10m
+    **connect peers task for service Finalization**;
+    startDelay; 2s
+    repeatDelay; 1m
+    **finalization task**;
+    startDelay; 2m
+    repeatDelay; 15s
+    **pull finalization messages task**;
+    startDelay; 3s
+    repeatDelay; 1s
+    **pull finalization proof task**;
+    startDelay; 10s
+    repeatDelay; 50s
+    **harvesting task**;
+    startDelay; 30s
+    repeatDelay; 1s
+    **network chain height detection**;
+    startDelay; 1s
+    repeatDelay; 15s
+    **node discovery peers task**;
+    startDelay; 1m
+    minDelay; 1m
+    maxDelay; 10m
+    numPhaseOneRounds; 10
+    numTransitionRounds; 20
+    **node discovery ping task**;
+    startDelay; 2m
+    repeatDelay; 5m
+    **age peers task for service Readers**;
+    startDelay; 1m
+    repeatDelay; 1m
+    **batch partial transaction task**;
+    startDelay; 500ms
+    repeatDelay; 500ms
+    **connect peers task for service Pt**;
+    startDelay; 3s
+    repeatDelay; 1m
+    **pull partial transactions task**;
+    startDelay; 10s
+    repeatDelay; 3s
+    **batch transaction task**;
+    startDelay; 500ms
+    repeatDelay; 500ms
+    **connect peers task for service Sync**;
+    startDelay; 1s
+    repeatDelay; 1m
+    **pull unconfirmed transactions task**;
+    startDelay; 4s
+    repeatDelay; 3s
+    **synchronizer task**;
+    startDelay; 3s
+    repeatDelay; 3s
+    **time synchronization task**;
+    startDelay; 1m
+    minDelay; 3m
+    maxDelay; 180m
+    numPhaseOneRounds; 5
+    numTransitionRounds; 10
+    **static node refresh task**;
+    startDelay; 5ms
+    minDelay; 15s
+    maxDelay; 24h
+    numPhaseOneRounds; 20
+    numTransitionRounds; 20
 
 config-timesync.properties
 ==========================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **timesynchronization**; ; ;
-    maxNodes;  ;  ;20
-    minImportance;  ;  ;3'750
+    **timesynchronization**;
+    maxNodes; 20
+    minImportance; 3'750
 
 config-user.properties
 ======================
 .. csv-table::
-    :header: "Property", "Type", "Description", "Value"
+    :header: "Property", "Value"
     :delim: ;
 
-    **account**; ; ;
-    enableDelegatedHarvestersAutoDetection;  ;  ;true
-    **storage**; ; ;
-    certificateDirectory;  ;  ;/userconfig/resources/cert
-    dataDirectory;  ;  ;/data
-    pluginsDirectory;  ;  ;/usr/catapult/lib
-    votingKeysDirectory;  ;  ;/data/votingkeys
+    **account**;
+    enableDelegatedHarvestersAutoDetection; true
+    **storage**;
+    certificateDirectory; /userconfig/resources/cert
+    dataDirectory; /data
+    pluginsDirectory; /usr/catapult/lib
+    votingKeysDirectory; /data/votingkeys

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -15,7 +15,7 @@ describe('BootstrapUtils', () => {
 
     it('BootstrapUtils loadPresetData testnet no assembly', async () => {
         try {
-            await BootstrapUtils.loadPresetData('.', Preset.testnet, undefined, undefined);
+            await BootstrapUtils.loadPresetData('.', Preset.testnet, undefined, undefined, undefined);
         } catch (e) {
             expect(e.message).to.equal('Preset testnet requires assembly (-a, --assembly option). Possible values are: api, dual, peer');
             return;
@@ -24,12 +24,18 @@ describe('BootstrapUtils', () => {
     });
 
     it('BootstrapUtils loadPresetData testnet assembly', async () => {
-        const presetData = await BootstrapUtils.loadPresetData('.', Preset.testnet, 'dual', undefined);
+        const presetData = await BootstrapUtils.loadPresetData('.', Preset.testnet, 'dual', undefined, undefined);
         expect(presetData).to.not.be.undefined;
     });
 
     it('BootstrapUtils loadPresetData bootstrap custom', async () => {
-        const presetData = await BootstrapUtils.loadPresetData('.', Preset.bootstrap, undefined, 'test/override-currency-preset.yml');
+        const presetData = await BootstrapUtils.loadPresetData(
+            '.',
+            Preset.bootstrap,
+            undefined,
+            'test/override-currency-preset.yml',
+            undefined,
+        );
         expect(presetData).to.not.be.undefined;
         expect(presetData?.nemesis?.mosaics?.[0].accounts).to.be.eq(20);
         const yaml = BootstrapUtils.toYaml(presetData);

--- a/test/service/ReportService.test.ts
+++ b/test/service/ReportService.test.ts
@@ -1,0 +1,39 @@
+import 'mocha';
+import { BootstrapUtils, ConfigService, Preset } from '../../src/service';
+import { ReportService } from '../../src/service/ReportService';
+import { expect } from '@oclif/test';
+
+describe('ReportService', () => {
+    it('ReportService testnet report', async () => {
+        const target = 'target/ReportService.testnet.report';
+        const customPresetObject = {
+            nodes: [
+                {
+                    voting: true,
+                    roles: 'Api,Peer,Voting',
+                    friendlyName: 'myFriendlyName',
+                    signingPrivateKey: '19CBD6AE842F9FDDC8F6F2AE8081981CF2268435BACA6A8A6A91740D631494BD',
+                    vrfPrivateKey: '620857FB100B5F34379DAD160C9A43D6B1BDC562D83DC37A468DD99D31C830F6',
+                },
+            ],
+        };
+        const configResult = await new ConfigService('.', {
+            ...ConfigService.defaultParams,
+            reset: true,
+            preset: Preset.testnet,
+            customPresetObject: customPresetObject,
+            assembly: 'dual',
+            target: target,
+            report: true,
+        }).run();
+
+        const paths = await new ReportService('.', { target }).run(configResult.presetData);
+        expect(paths.length).to.eq(1);
+        const reportPath = paths[0];
+        expect(reportPath).to.eq('target/ReportService.testnet.report/report/api-node-config.rst');
+
+        const generatedReport = await BootstrapUtils.readTextFile(reportPath);
+        const expectedReport = await BootstrapUtils.readTextFile('./test/expected-api-node-config.rst');
+        expect(generatedReport.trim()).to.be.eq(expectedReport.trim());
+    });
+});

--- a/test/service/ReportService.test.ts
+++ b/test/service/ReportService.test.ts
@@ -19,7 +19,7 @@ describe('ReportService', () => {
         };
         const configResult = await new ConfigService('.', {
             ...ConfigService.defaultParams,
-            reset: true,
+            reset: false,
             preset: Preset.testnet,
             customPresetObject: customPresetObject,
             assembly: 'dual',
@@ -28,12 +28,21 @@ describe('ReportService', () => {
         }).run();
 
         const paths = await new ReportService('.', { target }).run(configResult.presetData);
-        expect(paths.length).to.eq(1);
-        const reportPath = paths[0];
-        expect(reportPath).to.eq('target/ReportService.testnet.report/report/api-node-config.rst');
+        expect(paths.length).to.eq(2);
+        {
+            const reportPath = paths[0];
+            expect(reportPath).to.eq('target/ReportService.testnet.report/report/api-node-config.rst');
+            const generatedReport = await BootstrapUtils.readTextFile(reportPath);
+            const expectedReport = await BootstrapUtils.readTextFile('./test/expected-api-node-config.rst');
+            expect(generatedReport.trim()).to.be.eq(expectedReport.trim());
+        }
 
-        const generatedReport = await BootstrapUtils.readTextFile(reportPath);
-        const expectedReport = await BootstrapUtils.readTextFile('./test/expected-api-node-config.rst');
-        expect(generatedReport.trim()).to.be.eq(expectedReport.trim());
+        {
+            const reportPath = paths[1];
+            expect(reportPath).to.eq('target/ReportService.testnet.report/report/api-node-config.csv');
+            const generatedReport = await BootstrapUtils.readTextFile(reportPath);
+            const expectedReport = await BootstrapUtils.readTextFile('./test/expected-api-node-config.csv');
+            expect(generatedReport.trim()).to.be.eq(expectedReport.trim());
+        }
     });
 });


### PR DESCRIPTION
Hi @segfaultxavi @rg911 

I've added the "report" command that allows you to create RST files reporting the configured properties. Files are created in the `./target/report` folder

Examples:

```
symbol-bootstrap config --report 
symbol-bootstrap config --report -p testnet -a dual
symbol-bootstrap start --report
symbol-bootstrap report (after running a config)
```

An example of the generated report is the following:

https://github.com/nemtech/symbol-bootstrap/blob/config-report/test/expected-api-node-config.rst

The properties types and descriptions are kept in this [descriptions.yml](https://github.com/nemtech/symbol-bootstrap/blob/config-report/presets/descriptions.yml) file. The list is not comprehensive yet, we need to update the descriptions.yml file with all the possible keys. 

The idea is that you can generate the rst report files and copy them over symbol-docs to update guides like:

 https://docs.symbolplatform.com/guides/network/configuring-network-properties.html
 https://docs.symbolplatform.com/guides/network/configuring-node-properties.html

https://github.com/nemtech/symbol-docs/issues/516

- Added standalone command that generates rst files per node.
- Added --report to start and config commands
- Allowing API custom preset objects (instead of just a file).
- Added more customizable harvesting properties

Fixes https://github.com/nemtech/symbol-bootstrap/issues/21