### PR TITLE
Revisited lock files

### DIFF
--- a/cmds/healthCheck-bootstrap.sh
+++ b/cmds/healthCheck-bootstrap.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -e
 
-# docker rm -f $(docker ps -aq)
 symbol-bootstrap healthCheck -t target/bootstrap $1

--- a/cmds/healthCheck-testnet.sh
+++ b/cmds/healthCheck-testnet.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+symbol-bootstrap healthCheck -t target/testnet $1

--- a/config/docker/server/runServerRecover.sh.mustache
+++ b/config/docker/server/runServerRecover.sh.mustache
@@ -1,10 +1,11 @@
 #!/bin/bash
+set -e
+
 name=$1
 echo "RUNNING runServerRecover.sh $name"
 
 ulimit -c unlimited
-
-if [ -e "broker.lock" ] || [ -e "server.lock" ]; then
+if [ -e "{{{dataDirectory}}}/broker.lock" ] || [ -e "{{{dataDirectory}}}/server.lock" ]; then
   echo "!!!! Have lock file present, going to run recovery...."
   exec env LD_LIBRARY_PATH={{{catapultAppFolder}}}/lib:{{{catapultAppFolder}}}/deps {{{catapultAppFolder}}}/bin/catapult.recovery ./userconfig
   echo "!!!! Finished running recovery, should be moving on to start server..."

--- a/config/docker/server/startBroker.sh.mustache
+++ b/config/docker/server/startBroker.sh.mustache
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -e
 
 name=$1
-echo "RUNNING running startBroker.sh $name"
+echo "RUNNING startBroker.sh $name"
 
 ulimit -c unlimited
 

--- a/config/docker/server/startServer.sh.mustache
+++ b/config/docker/server/startServer.sh.mustache
@@ -1,9 +1,9 @@
 #!/bin/bash
+set -e
 
 name=$1
 echo "RUNNING startServer.sh $name"
 
 ulimit -c unlimited
-echo "!!!! Going to start server now...."
 
 exec env LD_LIBRARY_PATH={{{catapultAppFolder}}}/lib:{{{catapultAppFolder}}}/deps {{{catapultAppFolder}}}/bin/catapult.server ./userconfig

--- a/docs/run.md
+++ b/docs/run.md
@@ -40,8 +40,11 @@ OPTIONS
 
       The health check process handles 'repeat' and custom 'openPort' services.
 
+  --removeLocks
+      It removes the server.lock, broker.lock files from the nodes target folders. Use with caution!!!
+
   --resetData
-      It reset the database and node data but keeps the generated configuration, keys, voting tree files and block 1
+      It resets the database and node data but keeps the generated configuration, keys, voting tree files and block 1
 
   --timeout=timeout
       [default: 60000] If running in detached mode, how long before timing out (in milliseconds)

--- a/docs/start.md
+++ b/docs/start.md
@@ -56,11 +56,14 @@ OPTIONS
 
       The health check process handles 'repeat' and custom 'openPort' services.
 
+  --removeLocks
+      It removes the server.lock, broker.lock files from the nodes target folders. Use with caution!!!
+
   --report
       It generates reStructuredText (.rst) reports describing the configuration of each node.
 
   --resetData
-      It reset the database and node data but keeps the generated configuration, keys, voting tree files and block 1
+      It resets the database and node data but keeps the generated configuration, keys, voting tree files and block 1
 
   --timeout=timeout
       [default: 60000] If running in detached mode, how long before timing out (in milliseconds)

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -1,4 +1,5 @@
 nodeUseRemoteAccount: true
+sharedServerBrokerService: false
 nodePort: 7900
 enableCacheDatabaseStorage: true
 enableVerifiableState: true

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -38,7 +38,11 @@ export default class Run extends Command {
         }),
 
         resetData: flags.boolean({
-            description: 'It reset the database and node data but keeps the generated configuration, keys, voting tree files and block 1',
+            description: 'It resets the database and node data but keeps the generated configuration, keys, voting tree files and block 1',
+        }),
+
+        removeLocks: flags.boolean({
+            description: 'It removes the server.lock, broker.lock files from the nodes target folders. Use with caution!!!',
         }),
 
         args: flags.string({

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -94,6 +94,7 @@ export interface GatewayPreset extends DockerServicePreset {
 }
 
 export interface ConfigPreset {
+    sharedServerBrokerService: boolean;
     catapultAppFolder: string;
     subnet?: string;
     transactionsDirectory: string;

--- a/src/model/DockerCompose.ts
+++ b/src/model/DockerCompose.ts
@@ -34,6 +34,13 @@ export interface DockerComposeService {
     volumes?: string[];
     ports?: string[];
     depends_on?: string[];
+    healthcheck?: {
+        test: string[] | string;
+        interval: string;
+        timeout: string;
+        retries: number;
+        start_period: string;
+    };
     networks?: {
         default: {
             ipv4_address?: string;

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -151,7 +151,6 @@ export class BootstrapUtils {
         cmds: string[];
         binds: string[];
     }): Promise<{ stdout: string; stderr: string }> {
-        await BootstrapUtils.pullImage(image);
         const volumes = binds.map((b) => `-v ${b}`).join(' ');
         const userParam = userId ? `-u ${userId}` : '';
         const workdirParam = workdir ? `--workdir=${workdir}` : '';

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -6,6 +6,10 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db-0
         image: 'mongo:4.2.6-bionic'
+        networks:
+            default:
+                aliases: []
+        restart: unless-stopped
         command: mongod --dbpath=/dbdata --bind_ip=db-0
         stop_signal: SIGINT
         working_dir: /docker-entrypoint-initdb.d
@@ -20,6 +24,10 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db-1
         image: 'mongo:4.2.6-bionic'
+        networks:
+            default:
+                aliases: []
+        restart: unless-stopped
         command: mongod --dbpath=/dbdata --bind_ip=db-1
         stop_signal: SIGINT
         working_dir: /docker-entrypoint-initdb.d
@@ -34,6 +42,10 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db-2
         image: 'mongo:4.2.6-bionic'
+        networks:
+            default:
+                aliases: []
+        restart: unless-stopped
         command: mongod --dbpath=/dbdata --bind_ip=db-2
         stop_signal: SIGINT
         working_dir: /docker-entrypoint-initdb.d
@@ -48,6 +60,10 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db-3
         image: 'mongo:4.2.6-bionic'
+        networks:
+            default:
+                aliases: []
+        restart: unless-stopped
         command: mongod --dbpath=/dbdata --bind_ip=db-3
         stop_signal: SIGINT
         working_dir: /docker-entrypoint-initdb.d
@@ -59,144 +75,147 @@ services:
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
+        hostname: peer-node-0
+        networks:
+            default:
+                aliases:
+                    - peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports:
             - '7900:7900'
         volumes:
             - '../nodes/peer-node-0:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on: []
-        networks:
-            default:
-                aliases:
-                    - peer-node-0
-        hostname: peer-node-0
     peer-node-1:
         user: '1000:1000'
         container_name: peer-node-1
+        hostname: peer-node-1
+        networks:
+            default:
+                aliases:
+                    - peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports:
             - '7901:7900'
         volumes:
             - '../nodes/peer-node-1:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on: []
-        networks:
-            default:
-                aliases:
-                    - peer-node-1
-        hostname: peer-node-1
     peer-node-2:
         user: '1000:1000'
         container_name: peer-node-2
+        hostname: peer-node-2
+        networks:
+            default:
+                aliases:
+                    - peer-node-2
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  peer-node-2 && /bin/bash /symbol-commands/startServer.sh peer-node-2"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-2 && /bin/bash /symbol-commands/startServer.sh peer-node-2"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports:
             - '7902:7900'
         volumes:
             - '../nodes/peer-node-2:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on: []
-        networks:
-            default:
-                aliases:
-                    - peer-node-2
-        hostname: peer-node-2
     api-node-0:
         user: '1000:1000'
         container_name: api-node-0
+        hostname: api-node-0
+        networks:
+            default:
+                aliases:
+                    - api-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  api-node-0 && /bin/bash /symbol-commands/startServer.sh api-node-0"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-0 && /bin/bash /symbol-commands/startServer.sh api-node-0"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports: []
         volumes:
             - '../nodes/api-node-0:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
-            - api-node-broker-0
-        networks:
-            default:
-                aliases:
-                    - api-node-0
-        hostname: api-node-0
+            - db-0
     api-node-1:
         user: '1000:1000'
         container_name: api-node-1
+        hostname: api-node-1
+        networks:
+            default:
+                aliases:
+                    - api-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  api-node-1 && /bin/bash /symbol-commands/startServer.sh api-node-1"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-1 && /bin/bash /symbol-commands/startServer.sh api-node-1"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports: []
         volumes:
             - '../nodes/api-node-1:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
-            - api-node-broker-1
-        networks:
-            default:
-                aliases:
-                    - api-node-1
-        hostname: api-node-1
+            - db-1
     api-node-2:
         user: '1000:1000'
         container_name: api-node-2
+        hostname: api-node-2
+        networks:
+            default:
+                aliases:
+                    - api-node-2
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  api-node-2 && /bin/bash /symbol-commands/startServer.sh api-node-2"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-2 && /bin/bash /symbol-commands/startServer.sh api-node-2"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports: []
         volumes:
             - '../nodes/api-node-2:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
-            - api-node-broker-2
-        networks:
-            default:
-                aliases:
-                    - api-node-2
-        hostname: api-node-2
+            - db-2
     api-node-3:
         user: '1000:1000'
         container_name: api-node-3
+        hostname: api-node-3
+        networks:
+            default:
+                aliases:
+                    - api-node-3
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  api-node-3 && /bin/bash /symbol-commands/startServer.sh api-node-3"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-3 && /bin/bash /symbol-commands/startServer.sh api-node-3"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports: []
         volumes:
             - '../nodes/api-node-3:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
-            - api-node-broker-3
-        networks:
-            default:
-                aliases:
-                    - api-node-3
-        hostname: api-node-3
+            - db-3
     api-node-broker-0:
         user: '1000:1000'
         container_name: api-node-broker-0
+        hostname: api-node-broker-0
+        networks:
+            default:
+                aliases:
+                    - api-node-broker-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
         working_dir: /symbol-workdir
-        command: >-
-            bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-0 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-0"
+        command: /bin/bash /symbol-commands/startBroker.sh api-node-broker-0
         ports:
             - '8002:7902'
         stop_signal: SIGINT
@@ -204,14 +223,20 @@ services:
         volumes:
             - '../nodes/api-node-0:/symbol-workdir'
             - './server:/symbol-commands'
+        depends_on:
+            - db-0
+            - api-node-0
     api-node-broker-1:
         user: '1000:1000'
         container_name: api-node-broker-1
+        hostname: api-node-broker-1
+        networks:
+            default:
+                aliases:
+                    - api-node-broker-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
         working_dir: /symbol-workdir
-        command: >-
-            bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-1 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-1"
+        command: /bin/bash /symbol-commands/startBroker.sh api-node-broker-1
         ports:
             - '8003:7902'
         stop_signal: SIGINT
@@ -219,14 +244,20 @@ services:
         volumes:
             - '../nodes/api-node-1:/symbol-workdir'
             - './server:/symbol-commands'
+        depends_on:
+            - db-1
+            - api-node-1
     api-node-broker-2:
         user: '1000:1000'
         container_name: api-node-broker-2
+        hostname: api-node-broker-2
+        networks:
+            default:
+                aliases:
+                    - api-node-broker-2
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
         working_dir: /symbol-workdir
-        command: >-
-            bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-2 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-2"
+        command: /bin/bash /symbol-commands/startBroker.sh api-node-broker-2
         ports:
             - '8004:7902'
         stop_signal: SIGINT
@@ -234,14 +265,20 @@ services:
         volumes:
             - '../nodes/api-node-2:/symbol-workdir'
             - './server:/symbol-commands'
+        depends_on:
+            - db-2
+            - api-node-2
     api-node-broker-3:
         user: '1000:1000'
         container_name: api-node-broker-3
+        hostname: api-node-broker-3
+        networks:
+            default:
+                aliases:
+                    - api-node-broker-3
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
         working_dir: /symbol-workdir
-        command: >-
-            bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-3 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-3"
+        command: /bin/bash /symbol-commands/startBroker.sh api-node-broker-3
         ports:
             - '8005:7902'
         stop_signal: SIGINT
@@ -249,72 +286,88 @@ services:
         volumes:
             - '../nodes/api-node-3:/symbol-workdir'
             - './server:/symbol-commands'
+        depends_on:
+            - db-3
+            - api-node-3
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
+        networks:
+            default:
+                ipv4_address: 172.20.0.25
+                aliases: []
         image: 'symbolplatform/symbol-rest:2.1.1-alpha-202011162024'
+        working_dir: /symbol-workdir
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
-        working_dir: /symbol-workdir
+        restart: unless-stopped
         ports:
             - '3000:3000'
         volumes:
             - '../gateways/rest-gateway-0:/symbol-workdir'
         depends_on:
             - db-0
-        networks:
-            default:
-                ipv4_address: 172.20.0.25
+            - api-node-0
     rest-gateway-1:
         container_name: rest-gateway-1
         user: '1000:1000'
+        networks:
+            default:
+                ipv4_address: 172.20.0.26
+                aliases: []
         image: 'symbolplatform/symbol-rest:2.1.1-alpha-202011162024'
+        working_dir: /symbol-workdir
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
-        working_dir: /symbol-workdir
+        restart: unless-stopped
         ports:
             - '3001:3000'
         volumes:
             - '../gateways/rest-gateway-1:/symbol-workdir'
         depends_on:
             - db-1
-        networks:
-            default:
-                ipv4_address: 172.20.0.26
+            - api-node-1
     rest-gateway-2:
         container_name: rest-gateway-2
         user: '1000:1000'
+        networks:
+            default:
+                ipv4_address: 172.20.0.27
+                aliases: []
         image: 'symbolplatform/symbol-rest:2.1.1-alpha-202011162024'
+        working_dir: /symbol-workdir
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
-        working_dir: /symbol-workdir
+        restart: unless-stopped
         ports:
             - '3002:3000'
         volumes:
             - '../gateways/rest-gateway-2:/symbol-workdir'
         depends_on:
             - db-2
-        networks:
-            default:
-                ipv4_address: 172.20.0.27
+            - api-node-2
     rest-gateway-3:
         container_name: rest-gateway-3
         user: '1000:1000'
+        networks:
+            default:
+                ipv4_address: 172.20.0.28
+                aliases: []
         image: 'symbolplatform/symbol-rest:2.1.1-alpha-202011162024'
+        working_dir: /symbol-workdir
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
-        working_dir: /symbol-workdir
+        restart: unless-stopped
         ports:
             - '3003:3000'
         volumes:
             - '../gateways/rest-gateway-3:/symbol-workdir'
         depends_on:
             - db-3
-        networks:
-            default:
-                ipv4_address: 172.20.0.28
+            - api-node-3
 networks:
     default:
         ipam:
             config:
-                - subnet: 172.20.0.0/24
+                -
+                    subnet: 172.20.0.0/24

--- a/test/composes/expected-docker-compose-bootstrap-shared.yml
+++ b/test/composes/expected-docker-compose-bootstrap-shared.yml
@@ -27,9 +27,9 @@ services:
                 aliases:
                     - peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        working_dir: /symbol-workdir
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
         stop_signal: SIGINT
+        working_dir: /symbol-workdir
         restart: unless-stopped
         ports:
             - '7900:7900'
@@ -46,9 +46,9 @@ services:
                 aliases:
                     - peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        working_dir: /symbol-workdir
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
         stop_signal: SIGINT
+        working_dir: /symbol-workdir
         restart: unless-stopped
         ports:
             - '7901:7900'
@@ -64,38 +64,21 @@ services:
             default:
                 aliases:
                     - api-node-0
-        image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        working_dir: /symbol-workdir
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-0 && /bin/bash /symbol-commands/startServer.sh api-node-0"
-        stop_signal: SIGINT
-        restart: unless-stopped
-        ports: []
-        volumes:
-            - '../nodes/api-node-0:/symbol-workdir'
-            - './server:/symbol-commands'
-        depends_on:
-            - db-0
-    api-node-broker-0:
-        user: '1000:1000'
-        container_name: api-node-broker-0
-        hostname: api-node-broker-0
-        networks:
-            default:
-                aliases:
                     - api-node-broker-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
+        command: >-
+            bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-0 && /bin/bash /symbol-commands/startServer.sh api-node-0 &&
+            /bin/bash /symbol-commands/startBroker.sh api-node-broker-0"
+        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        command: /bin/bash /symbol-commands/startBroker.sh api-node-broker-0
+        restart: unless-stopped
         ports:
             - '8002:7902'
-        stop_signal: SIGINT
-        restart: 'on-failure:2'
         volumes:
             - '../nodes/api-node-0:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
             - db-0
-            - api-node-0
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'

--- a/test/composes/expected-testnet-dual-compose.yml
+++ b/test/composes/expected-testnet-dual-compose.yml
@@ -6,9 +6,13 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db
         image: 'mongo:4.2.6-bionic'
+        networks:
+            default:
+                aliases: []
+        restart: unless-stopped
         command: mongod --dbpath=/dbdata --bind_ip=db
-        working_dir: /docker-entrypoint-initdb.d
         stop_signal: SIGINT
+        working_dir: /docker-entrypoint-initdb.d
         ports: []
         volumes:
             - './mongo:/docker-entrypoint-initdb.d/:ro'
@@ -16,24 +20,34 @@ services:
     api-node:
         user: '1000:1000'
         container_name: api-node
+        hostname: api-node
+        networks:
+            default:
+                aliases:
+                    - api-node
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh  api-node && /bin/bash /symbol-commands/startServer.sh api-node"
-        stop_signal: SIGINT
         working_dir: /symbol-workdir
-        restart: 'on-failure:2'
+        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node && /bin/bash /symbol-commands/startServer.sh api-node"
+        stop_signal: SIGINT
+        restart: unless-stopped
         ports:
             - '7900:7900'
         volumes:
             - '../nodes/api-node:/symbol-workdir'
             - './server:/symbol-commands'
         depends_on:
-            - api-broker
+            - db
     api-broker:
         user: '1000:1000'
         container_name: api-broker
+        hostname: api-broker
+        networks:
+            default:
+                aliases:
+                    - api-broker
         image: 'symbolplatform/symbol-server:gcc-0.10.0.3'
         working_dir: /symbol-workdir
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-broker && /bin/bash /symbol-commands/startBroker.sh api-broker"
+        command: /bin/bash /symbol-commands/startBroker.sh api-broker
         ports:
             - '7902:7902'
         stop_signal: SIGINT
@@ -41,24 +55,31 @@ services:
         volumes:
             - '../nodes/api-node:/symbol-workdir'
             - './server:/symbol-commands'
+        depends_on:
+            - db
+            - api-node
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
+        networks:
+            default:
+                ipv4_address: 172.20.0.25
+                aliases: []
         image: 'symbolplatform/symbol-rest:2.1.1-alpha-202011162024'
+        working_dir: /symbol-workdir
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
-        working_dir: /symbol-workdir
+        restart: unless-stopped
         ports:
             - '3000:3000'
         volumes:
             - '../gateways/rest-gateway:/symbol-workdir'
         depends_on:
             - db
-        networks:
-            default:
-                ipv4_address: 172.20.0.25
+            - api-node
 networks:
     default:
         ipam:
             config:
-                - subnet: 172.20.0.0/24
+                -
+                    subnet: 172.20.0.0/24

--- a/test/service/ComposeService.test.ts
+++ b/test/service/ComposeService.test.ts
@@ -47,13 +47,13 @@ describe('ComposeService', () => {
         });
         await Promise.all(promises);
         expect(
-            dockerCompose,
+            BootstrapUtils.toYaml(dockerCompose),
             `Generated Docker Compose:
 
 ${BootstrapUtils.toYaml(dockerCompose)}
 
 `,
-        ).to.be.deep.eq(expectedDockerCompose);
+        ).to.be.eq(BootstrapUtils.toYaml(expectedDockerCompose));
     };
 
     it('Compose testnet dual', async () => {


### PR DESCRIPTION
- Added --removeLocks
- Fixed runSeverRecover lock files location

@Wayonb , could we revisit the runServerRecover.sh file and how it's called? Currently, it doesn't do anything in dev/main as it's looking for the lock files in the wrong location. I've fixed this but now the server doesn't start correctly. Why is the recovery process executed in both server and broker docker containers? Should only one container do the recovery? Should one container (broker?) wait for the other container (server?) to finish booting/recovering?

Related to https://github.com/nemtech/symbol-bootstrap/issues/64