### PR TITLE
Security - Memory Limit DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.2] - Dec-24-2020
+
+**Milestone**: Hippopotamus(0.10.0.4)
+
+ Package  | Version  | Link
+---|---|---
+Symbol Bootstrap | v0.3.1 | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap)
+
+- Added `mem_limit` in Testnet's mongo db services to 50% of the machine creating the docker compose file by default.
+- Fixed memory leak when concatenating `logText` on long OS span calls.
+- Masking 64 hex keys HIDDEN_KEY on log lines.
+- Removed unused Server configuration files in the Rest container. This reduces the risk of exposing config files if the Rest machine gets compromised.
+
 ## [0.3.1] - Dec-17-2020
 
 **Milestone**: Hippopotamus(0.10.0.4)

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ npm install -g symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (-v|--version|version)
-symbol-bootstrap/0.3.1 linux-x64 node-v12.18.4
+symbol-bootstrap/0.3.2 linux-x64 node-v12.18.4
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap clean
 ```
 
-_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/clean.ts)_
+_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/clean.ts)_

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -26,4 +26,4 @@ EXAMPLE
   $ symbol-bootstrap compose
 ```
 
-_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/compose.ts)_
+_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/compose.ts)_

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,4 +45,4 @@ EXAMPLE
   $ symbol-bootstrap config -p bootstrap
 ```
 
-_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/config.ts)_

--- a/docs/healthCheck.md
+++ b/docs/healthCheck.md
@@ -36,4 +36,4 @@ EXAMPLE
   $ symbol-bootstrap healthCheck
 ```
 
-_See code: [src/commands/healthCheck.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/healthCheck.ts)_
+_See code: [src/commands/healthCheck.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/healthCheck.ts)_

--- a/docs/link.md
+++ b/docs/link.md
@@ -24,4 +24,4 @@ EXAMPLE
   $ symbol-bootstrap link
 ```
 
-_See code: [src/commands/link.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/link.ts)_
+_See code: [src/commands/link.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/link.ts)_

--- a/docs/report.md
+++ b/docs/report.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap report
 ```
 
-_See code: [src/commands/report.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/report.ts)_
+_See code: [src/commands/report.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/report.ts)_

--- a/docs/resetData.md
+++ b/docs/resetData.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap resetData
 ```
 
-_See code: [src/commands/resetData.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/resetData.ts)_
+_See code: [src/commands/resetData.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/resetData.ts)_

--- a/docs/run.md
+++ b/docs/run.md
@@ -53,4 +53,4 @@ EXAMPLE
   $ symbol-bootstrap run
 ```
 
-_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/run.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -79,4 +79,4 @@ EXAMPLES
   $ symbol-bootstrap start -p testnet -a dual
 ```
 
-_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/start.ts)_
+_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/start.ts)_

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap stop
 ```
 
-_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.1/src/commands/stop.ts)_
+_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.3.2/src/commands/stop.ts)_

--- a/presets/testnet/assembly-api.yml
+++ b/presets/testnet/assembly-api.yml
@@ -1,6 +1,8 @@
 databases:
     - name: 'db'
       openPort: false
+      compose:
+          mem_limit: '{{computerMemory 50}}'
 nodes:
     - harvesting: false
       voting: false

--- a/presets/testnet/assembly-dual.yml
+++ b/presets/testnet/assembly-dual.yml
@@ -1,6 +1,8 @@
 databases:
     - name: 'db'
       openPort: false
+      compose:
+          mem_limit: '{{computerMemory 50}}'
 nodes:
     - harvesting: true
       voting: false

--- a/src/model/DockerCompose.ts
+++ b/src/model/DockerCompose.ts
@@ -34,6 +34,7 @@ export interface DockerComposeService {
     volumes?: string[];
     ports?: string[];
     depends_on?: string[];
+    mem_limit?: string | number;
     // https://docs.docker.com/compose/compose-file/#service-configuration-reference deploy section
     networks?: {
         default: {

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -271,6 +271,7 @@ export class BootstrapUtils {
         copyFrom: string,
         copyTo: string,
         excludeFiles: string[] = [],
+        includeFiles: string[] = [],
     ): Promise<void> {
         // Loop through all the files in the config folder
         await fsPromises.mkdir(copyTo, { recursive: true });
@@ -286,7 +287,9 @@ export class BootstrapUtils {
                     const isMustache = file.indexOf('.mustache') > -1;
                     const destinationFile = toPath.replace('.mustache', '');
                     const fileName = basename(destinationFile);
-                    if (excludeFiles.indexOf(fileName) === -1) {
+                    const notBlacklisted = excludeFiles.indexOf(fileName) === -1;
+                    const inWhitelistIfAny = includeFiles.length === 0 || includeFiles.indexOf(fileName) > -1;
+                    if (notBlacklisted && inWhitelistIfAny) {
                         if (isMustache) {
                             const template = await BootstrapUtils.readTextFile(fromPath);
                             const renderedTemplate = this.runTemplate(template, templateContext);
@@ -297,7 +300,7 @@ export class BootstrapUtils {
                     }
                 } else if (stat.isDirectory()) {
                     await fsPromises.mkdir(toPath, { recursive: true });
-                    await this.generateConfiguration(templateContext, fromPath, toPath, excludeFiles);
+                    await this.generateConfiguration(templateContext, fromPath, toPath, excludeFiles, includeFiles);
                 }
             }),
         );

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -112,8 +112,8 @@ export class CertificateService {
             binds: binds,
         });
         if (stdout.indexOf('Certificate Created') < 0) {
-            logger.info(stdout);
-            logger.error(stderr);
+            logger.info(BootstrapUtils.secureString(stdout));
+            logger.error(BootstrapUtils.secureString(stderr));
             throw new Error('Certificate creation failed. Check the logs!');
         }
 

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -311,11 +311,7 @@ export class ConfigLoader {
             if (service.repeat === 0) {
                 return [];
             }
-            if (!service.repeat) {
-                return [service];
-            }
-
-            return _.range(service.repeat).map((index) => {
+            return _.range(service.repeat || 1).map((index) => {
                 return _.omit(
                     _.mapValues(service, (v: any) => this.applyValueTemplate({ ...context, ...service, $index: index }, v)),
                     'repeat',

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -493,7 +493,13 @@ export class ConfigService {
                     'userconfig',
                     'resources',
                 );
-                await BootstrapUtils.generateConfiguration({}, apiNodeConfigFolder, join(moveTo, 'api-node-config'));
+                await BootstrapUtils.generateConfiguration(
+                    {},
+                    apiNodeConfigFolder,
+                    join(moveTo, 'api-node-config'),
+                    [],
+                    ['node.crt.pem', 'node.key.pem', 'ca.cert.pem', 'config-network.properties'],
+                );
             }),
         );
     }

--- a/test/composes/expected-testnet-dual-compose.yml
+++ b/test/composes/expected-testnet-dual-compose.yml
@@ -13,6 +13,7 @@ services:
         volumes:
             - './mongo:/docker-entrypoint-initdb.d:ro'
             - '../databases/db:/dbdata:rw'
+        mem_limit: 123
     api-node:
         user: '1000:1000'
         container_name: api-node

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -16,6 +16,7 @@
 
 import { expect } from '@oclif/test';
 import 'mocha';
+import { totalmem } from 'os';
 import { Account, Convert, Crypto, Deadline, NetworkType, UInt64, VotingKeyLinkTransaction, VotingKeyLinkV1Transaction } from 'symbol-sdk';
 import { BootstrapUtils } from '../../src/service';
 import assert = require('assert');
@@ -36,6 +37,29 @@ describe('BootstrapUtils', () => {
         expect(BootstrapUtils.toAmount(12345678)).to.be.eq("12'345'678");
         expect(BootstrapUtils.toAmount('12345678')).to.be.eq("12'345'678");
         expect(BootstrapUtils.toAmount("12'3456'78")).to.be.eq("12'345'678");
+    });
+
+    it('Bootstrap.secureText', function () {
+        expect(
+            BootstrapUtils.secureString(
+                '--secret=9F9D35D4BFA630012F074AAE11CF12191105EBA1435036FEF6AFAD8088918A62 --startEpoch=1 --endEpoch=26280 --output=/votingKeys/private_key_tree1.dat\n',
+            ),
+        ).to.be.eq('--secret=HIDDEN_KEY --startEpoch=1 --endEpoch=26280 --output=/votingKeys/private_key_tree1.dat\n');
+
+        expect(
+            BootstrapUtils.secureString(
+                'Running image using Exec: symbolplatform/symbol-server:tools-gcc-0.10.0.4 /usr/catapult/bin/catapult.tools.votingkey --secret=9F9D35D4BFA630012F074AAE11CF12191105EBA1435036FEF6AFAD8088918A62 --startEpoch=1 --endEpoch=26280 --output=/votingKeys/private_key_tree1.dat\n',
+            ),
+        ).to.be.eq(
+            'Running image using Exec: symbolplatform/symbol-server:tools-gcc-0.10.0.4 /usr/catapult/bin/catapult.tools.votingkey --secret=HIDDEN_KEY --startEpoch=1 --endEpoch=26280 --output=/votingKeys/private_key_tree1.dat\n',
+        );
+    });
+
+    it('BootstrapUtils.computerMemory', async () => {
+        const totalMemory = totalmem();
+        expect(totalMemory).to.be.gt(1024 * 1024);
+        expect(BootstrapUtils.computerMemory(100)).to.be.eq(totalMemory);
+        expect(BootstrapUtils.computerMemory(50)).to.be.eq(totalMemory / 2);
     });
 
     it('BootstrapUtils.toHex', async () => {

--- a/test/service/ComposeService.test.ts
+++ b/test/service/ComposeService.test.ts
@@ -26,6 +26,11 @@ describe('ComposeService', () => {
         const service = new BootstrapService('.');
         const configResult = await service.config(params);
         const dockerCompose = await service.compose(params, configResult.presetData);
+        Object.values(dockerCompose.services).forEach((service) => {
+            if (service.mem_limit) {
+                service.mem_limit = 123;
+            }
+        });
         const targetDocker = join(params.target, `docker`, 'docker-compose.yml');
         expect(existsSync(targetDocker)).to.be.true;
         const expectedFileLocation = `./test/composes/${expectedComposeFile}`;

--- a/test/service/ConfigLoader.test.ts
+++ b/test/service/ConfigLoader.test.ts
@@ -159,14 +159,14 @@ describe('ConfigLoader', () => {
 
         const expectedExpandedServices = [
             {
-                apiNodeName: 'api-node-{{$index}}',
-                apiNodeHost: 'api-node-{{$index}}',
-                apiNodeBrokerHost: 'api-node-broker-{{$index}}',
-                name: 'rest-gateway-{{$index}}',
+                apiNodeBrokerHost: 'api-node-broker-0',
+                apiNodeHost: 'api-node-0',
+                apiNodeName: 'api-node-0',
+                databaseHost: 'db-0',
                 description: 'catapult development network',
-                databaseHost: 'db-{{$index}}',
+                ipv4_address: '172.20.0.5',
+                name: 'rest-gateway-0',
                 openPort: true,
-                ipv4_address: '172.20.0.{{add $index 5}}',
             },
         ];
         expect(expandedServices).to.be.deep.eq(expectedExpandedServices);


### PR DESCRIPTION
Few fixes:

1 - mem_limit in testnet's mongo to 50% of the machine configuring bootstrap (creating the compose file)
2 - Fixed memory leak when concatenating logText on long span
3 - Masking 64 hex keys HIDDEN_KEY on logs (we may need to replicate this in other places)
4 - Only copying required configuration files and certificates to Rest from server to reduce the risk of exposing configuration if the rest box gets compromised