### PR TITLE
Pruning compose files

### DIFF
--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -323,6 +323,22 @@ export class BootstrapUtils {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    public static pruneEmpty(obj: any): any {
+        return (function prune(current: any) {
+            _.forOwn(current, (value, key) => {
+                if (_.isUndefined(value) || _.isNull(value) || _.isNaN(value) || (_.isObject(value) && _.isEmpty(prune(value)))) {
+                    delete current[key];
+                }
+            });
+            // remove any leftover undefined values from the delete
+            // operation on an array
+            if (_.isArray(current)) _.pull(current, undefined);
+
+            return current;
+        })(_.cloneDeep(obj)); // Do not modify the original object, create a clone instead
+    }
+
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     public static toYaml(object: any): string {
         return yaml.safeDump(object, { skipInvalid: true, indent: 4, lineWidth: 140, noRefs: true });
     }

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -318,7 +318,7 @@ export class ComposeService {
 
         const validServices: DockerComposeService[] = services.filter((s) => s).map((s) => s as DockerComposeService);
         const servicesMap: Record<string, DockerComposeService> = _.keyBy(validServices, 'container_name');
-        const dockerCompose: DockerCompose = {
+        let dockerCompose: DockerCompose = {
             version: presetData.dockerComposeVersion,
             services: servicesMap,
         };
@@ -336,6 +336,7 @@ export class ComposeService {
                 },
             };
 
+        dockerCompose = BootstrapUtils.pruneEmpty(dockerCompose);
         await BootstrapUtils.writeYaml(dockerFile, dockerCompose);
         logger.info(`docker-compose.yml file created ${dockerFile}`);
         return dockerCompose;

--- a/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
@@ -33,7 +33,7 @@ services:
         volumes:
             - '../nodes/peer-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         cpu_count: 4
         shm_size: 64M
         deploy:
@@ -58,7 +58,7 @@ services:
         volumes:
             - '../nodes/peer-node-1:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         cpu_count: 4
         shm_size: 64M
         deploy:
@@ -78,7 +78,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'

--- a/test/composes/expected-docker-compose-bootstrap-full.yml
+++ b/test/composes/expected-docker-compose-bootstrap-full.yml
@@ -27,7 +27,7 @@ services:
         volumes:
             - '../nodes/peer-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -46,7 +46,7 @@ services:
         volumes:
             - '../nodes/peer-node-1:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -60,7 +60,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -69,7 +69,7 @@ services:
         volumes:
             - '../nodes/peer-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -88,7 +88,7 @@ services:
         volumes:
             - '../nodes/peer-node-1:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -107,7 +107,7 @@ services:
         volumes:
             - '../nodes/peer-node-2:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -121,7 +121,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
@@ -140,7 +140,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-1:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
@@ -159,7 +159,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-2:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
@@ -178,7 +178,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-3:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'

--- a/test/composes/expected-docker-compose-bootstrap.yml
+++ b/test/composes/expected-docker-compose-bootstrap.yml
@@ -27,7 +27,7 @@ services:
         volumes:
             - '../nodes/peer-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -46,7 +46,7 @@ services:
         volumes:
             - '../nodes/peer-node-1:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'
-        depends_on: []
+
         networks:
             default:
                 aliases:
@@ -60,7 +60,7 @@ services:
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
-        ports: []
+
         volumes:
             - '../nodes/api-node-0:/symbol-workdir:rw'
             - './server:/symbol-commands:ro'

--- a/test/composes/expected-testnet-voting-compose.yml
+++ b/test/composes/expected-testnet-voting-compose.yml
@@ -13,7 +13,6 @@ services:
         volumes:
             - './mongo:/docker-entrypoint-initdb.d:ro'
             - '../databases/db:/dbdata:rw'
-        mem_limit: 123
     api-node:
         user: '1000:1000'
         container_name: api-node

--- a/test/service/BootstrapUtils.test.ts
+++ b/test/service/BootstrapUtils.test.ts
@@ -16,6 +16,7 @@
 
 import { expect } from '@oclif/test';
 import 'mocha';
+import { it } from 'mocha';
 import { totalmem } from 'os';
 import { Account, Convert, Crypto, Deadline, NetworkType, UInt64, VotingKeyLinkTransaction, VotingKeyLinkV1Transaction } from 'symbol-sdk';
 import { BootstrapUtils } from '../../src/service';
@@ -187,5 +188,69 @@ describe('BootstrapUtils', () => {
         expect(transaction.endEpoch).to.be.eq(presetData.votingKeyEndEpoch);
         expect(transaction.maxFee).to.be.deep.eq(maxFee);
         expect(transaction.deadline).to.be.deep.eq(deadline);
+    });
+
+    it('should remove null values', () => {
+        const compose = {
+            version: '2.4',
+            services: {
+                db: {
+                    user: '',
+                    environment: {
+                        MONGO_INITDB_DATABASE: 'null',
+                    },
+                    container_name: 'db',
+                    image: 'mongo:4.2.6-bionic',
+                    command: 'mongod --dbpath=/dbdata --bind_ip=db',
+                    stop_signal: 'SIGINT',
+                    working_dir: '/docker-entrypoint-initdb.d',
+                    ports: [],
+                    volumes: ['./mongo:/docker-entrypoint-initdb.d:ro', '../databases/db:/dbdata:rw'],
+                    mem_limit: null,
+                },
+                networks: {
+                    default: {
+                        ipam: {
+                            config: [
+                                {
+                                    subnet: '172.20.0.0/24',
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+        const composePruned = {
+            version: '2.4',
+            services: {
+                db: {
+                    user: '',
+                    environment: {
+                        MONGO_INITDB_DATABASE: 'null',
+                    },
+                    container_name: 'db',
+                    image: 'mongo:4.2.6-bionic',
+                    command: 'mongod --dbpath=/dbdata --bind_ip=db',
+                    stop_signal: 'SIGINT',
+                    working_dir: '/docker-entrypoint-initdb.d',
+                    volumes: ['./mongo:/docker-entrypoint-initdb.d:ro', '../databases/db:/dbdata:rw'],
+                },
+                networks: {
+                    default: {
+                        ipam: {
+                            config: [
+                                {
+                                    subnet: '172.20.0.0/24',
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(BootstrapUtils.pruneEmpty(compose)).to.deep.eq(composePruned);
     });
 });

--- a/test/service/ComposeService.test.ts
+++ b/test/service/ComposeService.test.ts
@@ -75,6 +75,19 @@ ${BootstrapUtils.toYaml(dockerCompose)}
         await assertDockerCompose(params, 'expected-testnet-dual-compose.yml');
     });
 
+    it('Compose testnet dual voting', async () => {
+        const params = {
+            ...ConfigService.defaultParams,
+            ...LinkService.defaultParams,
+            target: 'target/testnet-voting',
+            reset: false,
+            customPreset: './test/voting_preset.yml',
+            preset: Preset.testnet,
+            assembly: 'dual',
+        };
+        await assertDockerCompose(params, 'expected-testnet-voting-compose.yml');
+    });
+
     it('Compose bootstrap default', async () => {
         const params = {
             ...ConfigService.defaultParams,
@@ -142,7 +155,7 @@ ${BootstrapUtils.toYaml(dockerCompose)}
                     },
                 ],
             },
-            reset: true,
+            reset: false,
             target: 'target/ConfigService.bootstrap.repeat',
             preset: Preset.bootstrap,
             customPreset: './test/repeat_preset.yml',

--- a/test/voting_preset.yml
+++ b/test/voting_preset.yml
@@ -1,2 +1,5 @@
+databases:
+    - compose:
+          mem_limit: ~
 nodes:
     - voting: true


### PR DESCRIPTION
Small improvement allowing users to remove default values from presets. For example:

````
databases:
    - compose:
          mem_limit: ~
````
It also removes unnecessary empty fields from docker compose. 

Related to https://github.com/nemtech/symbol-bootstrap/issues/101 (Although it would need the memory limit most likely)