### PR TITLE
Compose Debug Mode

### DIFF
--- a/cmds/start-bootstrap-full.sh
+++ b/cmds/start-bootstrap-full.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-symbol-bootstrap start -p bootstrap -a full -t target/bootstrap $1 $2 $3
+symbol-bootstrap start -p bootstrap -a full -t target/bootstrap -c test/full_preset.yml $1 $2 $3

--- a/docs/presetGuides.md
+++ b/docs/presetGuides.md
@@ -255,3 +255,37 @@ This is done by passing [docker-compose up](https://docs.docker.com/compose/refe
 ```
 symbol-bootstrap start -r --args "--scale rest-gateway-0=0"
 ```
+
+**Enable compose debug mode**
+
+It adds debug attributes to the docker compose services. The attributes are:
+
+```
+security_opt:
+    - 'seccomp:unconfined'
+cap_add:
+    - ALL
+privileged: true 
+```
+
+By default, debug mode is disabled. You can enable debug mode in each service.
+
+````
+gateways:
+    - dockerComposeDebugMode: true # debug mode in gateway
+nodes:
+    - dockerComposeDebugMode: true # debug mode in node
+      brokerDockerComposeDebugMode: true # debug mode in broker
+````
+
+Alternatively, you can enable debug mode for all the services, but then disable them by one by. 
+
+
+````
+dockerComposeDebugMode: true # adds debug mode attributes to all the services
+databases:
+    - dockerComposeDebugMode: false # excluding the database
+nodes:
+    - brokerDockerComposeDebugMode: false # excluding the broker
+````
+

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -146,6 +146,7 @@ maxUnlockedAccounts: 5
 delegatePrioritizationPolicy: Importance
 dockerComposeVersion: '2.4'
 dockerComposeServiceRestart: 'on-failure:2'
+dockerComposeDebugMode: false
 
 minPartnerNodeVersion: 0.10.0.4
 maxPartnerNodeVersion: 0.10.0.4

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -24,6 +24,7 @@ export interface DockerServicePreset {
     excludeDockerService?: boolean;
     environment?: any;
     compose?: any;
+    dockerComposeDebugMode?: boolean;
 }
 
 export interface MosaicPreset {
@@ -85,7 +86,7 @@ export interface NodePreset extends DockerServicePreset {
     brokerOpenPort?: boolean | number | string;
     brokerExcludeDockerService?: boolean;
     brokerCompose?: any;
-
+    brokerDockerComposeDebugMode?: boolean;
     //super node
     supernode?: boolean | string;
     supernodeOpenPort?: boolean | number | string;
@@ -150,6 +151,7 @@ export interface ConfigPreset {
     networkheight: boolean;
     dockerComposeVersion: number | string;
     dockerComposeServiceRestart: string;
+    dockerComposeDebugMode: boolean;
     nodes?: NodePreset[];
     gateways?: GatewayPreset[];
     explorers?: ExplorerPreset[];

--- a/src/model/DockerCompose.ts
+++ b/src/model/DockerCompose.ts
@@ -42,6 +42,10 @@ export interface DockerComposeService {
             aliases?: string[];
         };
     };
+    // DEBUG MODE
+    privileged?: boolean;
+    cap_add?: string[];
+    security_opt?: string[];
 }
 
 export interface DockerCompose {

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -46,10 +46,26 @@ export class ComposeService {
         upgrade: false,
     };
 
+    public static readonly DEBUG_SERVICE_PARAMS = {
+        security_opt: ['seccomp:unconfined'],
+        cap_add: ['ALL'],
+        privileged: true,
+    };
+
     private readonly configLoader: ConfigLoader;
 
     constructor(private readonly root: string, protected readonly params: ComposeParams) {
         this.configLoader = new ConfigLoader();
+    }
+
+    public resolveDebugOptions(dockerComposeDebugMode: boolean, dockerComposeServiceDebugMode: boolean | undefined) {
+        if (dockerComposeServiceDebugMode == false) {
+            return {};
+        }
+        if (dockerComposeServiceDebugMode || dockerComposeDebugMode) {
+            return ComposeService.DEBUG_SERVICE_PARAMS;
+        }
+        return {};
     }
 
     public async run(passedPresetData?: ConfigPreset, passedAddresses?: Addresses): Promise<DockerCompose> {
@@ -164,6 +180,7 @@ export class ComposeService {
                                 vol(`./mongo`, `/docker-entrypoint-initdb.d`, true),
                                 vol(`../${targetDatabasesFolder}/${n.name}`, '/dbdata', false),
                             ],
+                            ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                             ...n.compose,
                         }),
                     );
@@ -223,6 +240,7 @@ export class ComposeService {
                         ports: resolvePorts(portConfigurations),
                         volumes: volumes,
                         depends_on: serverDependsOn,
+                        ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                         ...n.compose,
                     });
 
@@ -246,6 +264,7 @@ export class ComposeService {
                                     stop_signal: 'SIGINT',
                                     restart: restart,
                                     volumes: nodeService.volumes,
+                                    ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.brokerDockerComposeDebugMode),
                                     ...n.brokerCompose,
                                 },
                             ),
@@ -272,6 +291,7 @@ export class ComposeService {
                             restart: restart,
                             volumes: volumes,
                             depends_on: [n.databaseHost],
+                            ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                             ...n.compose,
                         }),
                     );
@@ -292,6 +312,7 @@ export class ComposeService {
                             ports: resolvePorts([{ internalPort: 80, openPort: n.openPort }]),
                             restart: restart,
                             volumes: volumes,
+                            ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                             ...n.compose,
                         }),
                     );
@@ -316,6 +337,7 @@ export class ComposeService {
                             ports: resolvePorts([{ internalPort: 80, openPort: n.openPort }]),
                             restart: restart,
                             volumes: volumes,
+                            ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                             ...n.compose,
                         }),
                     );
@@ -342,6 +364,7 @@ export class ComposeService {
                             restart: restart,
                             ports: resolvePorts([{ internalPort: 4000, openPort: n.openPort }]),
                             depends_on: [n.gateway],
+                            ...this.resolveDebugOptions(presetData.dockerComposeDebugMode, n.dockerComposeDebugMode),
                             ...n.compose,
                         }),
                     );

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -14,11 +14,6 @@ services:
         volumes:
             - './mongo:/docker-entrypoint-initdb.d:ro'
             - '../databases/db-0:/dbdata:rw'
-        security_opt:
-            - 'seccomp:unconfined'
-        cap_add:
-            - ALL
-        privileged: true
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
@@ -130,67 +125,9 @@ services:
         networks:
             default:
                 ipv4_address: 172.20.0.25
-    wallet-0:
-        container_name: wallet-0
-        image: 'symbolplatform/symbol-desktop-wallet:0.13.6'
-        stop_signal: SIGINT
-        working_dir: /symbol-workdir
-        ports:
-            - '80:80'
-        restart: 'on-failure:2'
-        volumes:
-            - '../wallets/wallet-0:/usr/share/nginx/html/config:ro'
-        security_opt:
-            - 'seccomp:unconfined'
-        cap_add:
-            - ALL
-        privileged: true
-    explorer-0:
-        container_name: explorer-0
-        image: 'symbolplatform/symbol-explorer:0.6.3-alpha'
-        command: ash -c "/bin/ash /symbol-commands/run.sh explorer-0"
-        stop_signal: SIGINT
-        working_dir: /symbol-workdir
-        ports:
-            - '90:80'
-        restart: 'on-failure:2'
-        volumes:
-            - '../explorers/explorer-0:/symbol-workdir:ro'
-            - './explorer:/symbol-commands:ro'
-        security_opt:
-            - 'seccomp:unconfined'
-        cap_add:
-            - ALL
-        privileged: true
-    faucet-0:
-        container_name: faucet-0
-        image: 'symbolplatform/symbol-faucet:0.4.0'
-        stop_signal: SIGINT
-        environment:
-            DEFAULT_NODE: 'http://rest-gateway-0:3000'
-            DEFAULT_NODE_CLIENT: 'http://localhost:3000'
-            NATIVE_CURRENCY_NAME: cat.currency
-            NATIVE_CURRENCY_OUT_MAX: 500000000
-            NATIVE_CURRENCY_OUT_MIN: 100000000
-            MAX_FEE: 5000000
-            ENOUGH_BALANCE: 100000000000
-            MAX_UNCONFIRMED: 99
-            BLACKLIST_MOSAIC_IDS: '[]'
-            EXPLORER_URL: 'http://localhost:90/'
-            FAUCET_PRIVATE_KEY: MockMe
-            NATIVE_CURRENCY_ID: Mockme2
-        restart: 'on-failure:2'
-        ports:
-            - '100:4000'
-        depends_on:
-            - rest-gateway-0
-        security_opt:
-            - 'seccomp:unconfined'
-        cap_add:
-            - ALL
-        privileged: true
 networks:
     default:
         ipam:
             config:
-                - subnet: 172.20.0.0/24
+                -
+                    subnet: 172.20.0.0/24

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -6,7 +6,7 @@ services:
             MONGO_INITDB_DATABASE: catapult
         container_name: db-0
         image: 'mongo:4.2.6-bionic'
-        command: mongod --dbpath=/dbdata --bind_ip=db-0
+        command: mongod --dbpath=/dbdata --bind_ip=db-0 --wiredTigerCacheSizeGB 2
         stop_signal: SIGINT
         working_dir: /docker-entrypoint-initdb.d
         ports:

--- a/test/custom_preset.yml
+++ b/test/custom_preset.yml
@@ -4,11 +4,14 @@ baseNamespace: 'bob'
 currencyName: 'marley'
 harvestingName: 'reggae'
 nemesisGenerationHashSeed: 6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD
+dockerComposeDebugMode: true
 #totalChainImportance: 8998999998000000
 #nemesis:
 ##   Disable harvest currency with repeat 0
 #   mosaics: [{}, { repeat: 0 }]
 
+databases:
+    - dockerComposeDebugMode: false
 nemesis:
     nemesisSignerPrivateKey: B2AF9675B7AA8CCCBB3C1072256B3DF7354223FB5C490FFBDDB1C60696E25219
     balances:

--- a/test/full_preset.yml
+++ b/test/full_preset.yml
@@ -1,0 +1,1 @@
+dockerComposeDebugMode: true


### PR DESCRIPTION
**Enable compose debug mode**

It adds debug attributes to the docker compose services. The attributes are:

```
security_opt:
    - 'seccomp:unconfined'
cap_add:
    - ALL
privileged: true 
```

By default, debug mode is disabled. You can enable debug mode in each service.

````
gateways:
    - dockerComposeDebugMode: true # debug mode in gateway
nodes:
    - dockerComposeDebugMode: true # debug mode in node
      brokerDockerComposeDebugMode: true # debug mode in broker
````

Alternatively, you can enable debug mode for all the services, but then disable them by one by. 

````
dockerComposeDebugMode: true # adds debug mode attributes to all the services
databases:
    - dockerComposeDebugMode: false # excluding the database
nodes:
    - brokerDockerComposeDebugMode: false # excluding the broker
````

(This is the description in the new presetGuides.md)

Fixes

https://github.com/nemtech/symbol-bootstrap/issues/106