### PR TITLE
Controller public key agent configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Symbol Bootstrap | v0.4.1 | [symbol-bootstrap](https://www.npmjs.com/package/sym
 - Added `database` service to server and broker `depends_on` compose services.
 - Fixed `link --unlink` command for Voting Key Link transactions.
 - Added multisig account validation to `link` and `supernode` commands.
+- Added `CONTROLLER_PUBLIC_KEY` to Supernode's agent configuration
 
 ## [0.4.0] - Jan-14-2020
 

--- a/config/node/agent/agent.properties.mustache
+++ b/config/node/agent/agent.properties.mustache
@@ -2,7 +2,7 @@ NODE_PRIVATE_KEY={{{nodePrivateKey}}}
 LOGGER_FILE=logs/agent.log
 REST_GATEWAY_URL={{{restGatewayUrl}}}
 REWARD_PROGRAM={{{rewardProgram}}}
+CONTROLLER_PUBLIC_KEY={{{supernodeControllerPublicKey}}}
 CERTS_CA_FILE={{{supernodeCaFile}}}
 CERTS_KEY_FILE=userconfig/agent/agent-key.pem
 CERTS_CERT_FILE=userconfig/agent/agent-crt.pem
-


### PR DESCRIPTION
Added controller public key to the agent configuration. 

The controller account/public key is the recipient address for the supernode registration. This public key is not used yet but we may use it for agent->agent validation. 