### PR TITLE
Core dump when dockerComposeDebugMode: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ npm install -g symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (-v|--version|version)
-symbol-bootstrap/0.4.2 linux-x64 node-v10.23.2
+symbol-bootstrap/0.4.3 linux-x64 node-v12.18.4
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND

--- a/cmds/start-bootstrap.sh
+++ b/cmds/start-bootstrap.sh
@@ -2,4 +2,4 @@
 set -e
 
 # docker rm -f $(docker ps -aq)
-symbol-bootstrap start -p bootstrap -u current -t target/bootstrap --password 1234 $1 $2 $3
+symbol-bootstrap start -p bootstrap -u current -t target/bootstrap  -c test/custom_bootstrap.yml --password 1234 $1

--- a/config/docker/server/startBroker.sh.mustache
+++ b/config/docker/server/startBroker.sh.mustache
@@ -2,10 +2,17 @@
 set -e
 
 name=$1
-echo "RUNNING startBroker.sh $name"
+mode=$2
+
+echo "RUNNING startBroker.sh $name $mode"
 
 ulimit -c unlimited
 
+if [ "$mode" == "DEBUG" ]; then
+  echo "Setting up core dump..."
+  mkdir -p ./logs
+  echo './logs/broker.%e.%t' > /proc/sys/kernel/core_pattern
+fi
 
 touch ./data/broker.started
 

--- a/config/docker/server/startServer.sh.mustache
+++ b/config/docker/server/startServer.sh.mustache
@@ -2,8 +2,16 @@
 set -e
 
 name=$1
-echo "RUNNING startServer.sh $name"
+mode=$2
+
+echo "RUNNING startServer.sh $name $mode"
 
 ulimit -c unlimited
+
+if [ "$mode" == "DEBUG" ]; then
+  echo "Setting up core dump..."
+  mkdir -p ./logs
+  echo './logs/server.%e.%t' >/proc/sys/kernel/core_pattern
+fi
 
 exec env LD_LIBRARY_PATH={{{catapultAppFolder}}}/lib:{{{catapultAppFolder}}}/deps {{{catapultAppFolder}}}/bin/catapult.server ./userconfig

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap clean
 ```
 
-_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/clean.ts)_
+_See code: [src/commands/clean.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/clean.ts)_

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -26,4 +26,4 @@ EXAMPLE
   $ symbol-bootstrap compose
 ```
 
-_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/compose.ts)_
+_See code: [src/commands/compose.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/compose.ts)_

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,4 +45,4 @@ EXAMPLE
   $ symbol-bootstrap config -p bootstrap
 ```
 
-_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/config.ts)_

--- a/docs/enrolSupernode.md
+++ b/docs/enrolSupernode.md
@@ -28,4 +28,4 @@ EXAMPLE
   $ symbol-bootstrap enrolSupernode
 ```
 
-_See code: [src/commands/enrolSupernode.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/enrolSupernode.ts)_
+_See code: [src/commands/enrolSupernode.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/enrolSupernode.ts)_

--- a/docs/healthCheck.md
+++ b/docs/healthCheck.md
@@ -36,4 +36,4 @@ EXAMPLE
   $ symbol-bootstrap healthCheck
 ```
 
-_See code: [src/commands/healthCheck.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/healthCheck.ts)_
+_See code: [src/commands/healthCheck.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/healthCheck.ts)_

--- a/docs/link.md
+++ b/docs/link.md
@@ -30,4 +30,4 @@ EXAMPLE
   $ symbol-bootstrap link
 ```
 
-_See code: [src/commands/link.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/link.ts)_
+_See code: [src/commands/link.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/link.ts)_

--- a/docs/report.md
+++ b/docs/report.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap report
 ```
 
-_See code: [src/commands/report.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/report.ts)_
+_See code: [src/commands/report.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/report.ts)_

--- a/docs/resetData.md
+++ b/docs/resetData.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap resetData
 ```
 
-_See code: [src/commands/resetData.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/resetData.ts)_
+_See code: [src/commands/resetData.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/resetData.ts)_

--- a/docs/run.md
+++ b/docs/run.md
@@ -53,4 +53,4 @@ EXAMPLE
   $ symbol-bootstrap run
 ```
 
-_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/run.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -79,4 +79,4 @@ EXAMPLES
   $ symbol-bootstrap start -p testnet -a dual
 ```
 
-_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/start.ts)_
+_See code: [src/commands/start.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/start.ts)_

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -21,4 +21,4 @@ EXAMPLE
   $ symbol-bootstrap stop
 ```
 
-_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.2/src/commands/stop.ts)_
+_See code: [src/commands/stop.ts](https://github.com/nemtech/symbol-bootstrap/blob/v0.4.3/src/commands/stop.ts)_

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -50,6 +50,7 @@ export class ComposeService {
         security_opt: ['seccomp:unconfined'],
         cap_add: ['ALL'],
         privileged: true,
+        ulimits: { core: -1 },
     };
 
     private readonly configLoader: ConfigLoader;
@@ -193,10 +194,12 @@ export class ComposeService {
             (presetData.nodes || [])
                 .filter((d) => !d.excludeDockerService)
                 .map(async (n) => {
+                    const serverDebugMode = presetData.dockerComposeDebugMode || n.dockerComposeDebugMode ? ' DEBUG' : '';
+                    const brokerDebugMode = presetData.dockerComposeDebugMode || n.brokerDockerComposeDebugMode ? ' DEBUG' : '';
                     const waitForBroker = `/bin/bash ${nodeCommandsDirectory}/wait.sh ./data/broker.started`;
                     const recoverServerCommand = `/bin/bash ${nodeCommandsDirectory}/runServerRecover.sh ${n.name}`;
-                    let serverCommand = `/bin/bash ${nodeCommandsDirectory}/startServer.sh ${n.name}`;
-                    const brokerCommand = `/bin/bash ${nodeCommandsDirectory}/startBroker.sh ${n.brokerName || ''}`;
+                    let serverCommand = `/bin/bash ${nodeCommandsDirectory}/startServer.sh ${n.name}${serverDebugMode}`;
+                    const brokerCommand = `/bin/bash ${nodeCommandsDirectory}/startBroker.sh ${n.brokerName || 'broker'}${brokerDebugMode}`;
                     const recoverBrokerCommand = `/bin/bash ${nodeCommandsDirectory}/runServerRecover.sh ${n.brokerName || ''}`;
                     const portConfigurations = [{ internalPort: 7900, openPort: n.openPort }];
 
@@ -358,7 +361,6 @@ export class ComposeService {
             (presetData.faucets || [])
                 .filter((d) => !d.excludeDockerService)
                 .map(async (n) => {
-                    const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
                     // const nemesisPrivateKey = addresses?.mosaics?[0]?/;
                     services.push(
                         await resolveService(n, {
@@ -367,7 +369,7 @@ export class ComposeService {
                             stop_signal: 'SIGINT',
                             environment: {
                                 FAUCET_PRIVATE_KEY:
-                                    n.environment?.FAUCET_PRIVATE_KEY || addresses?.mosaics?.[0]?.accounts[0].privateKey || '',
+                                    n.environment?.FAUCET_PRIVATE_KEY || this.getMainAccountPrivateKey(passedAddresses) || '',
                                 NATIVE_CURRENCY_ID: BootstrapUtils.toSimpleHex(
                                     n.environment?.NATIVE_CURRENCY_ID || presetData.currencyMosaicId || '',
                                 ),
@@ -406,5 +408,10 @@ export class ComposeService {
         await BootstrapUtils.writeYaml(dockerFile, dockerCompose, undefined);
         logger.info(`docker-compose.yml file created ${dockerFile}`);
         return dockerCompose;
+    }
+
+    private getMainAccountPrivateKey(passedAddresses: Addresses | undefined) {
+        const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
+        return addresses?.mosaics?.[0]?.accounts[0].privateKey;
     }
 }

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -32,6 +32,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -55,6 +57,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -79,6 +83,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -91,7 +97,7 @@ services:
         working_dir: /symbol-workdir
         command: >-
             bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-0 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-0"
+            api-node-broker-0 DEBUG"
         ports:
             - '8002:7902'
         stop_signal: SIGINT
@@ -106,6 +112,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
@@ -125,6 +133,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 ipv4_address: 172.20.0.25

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -15,7 +15,6 @@ services:
             - './mongo:/docker-entrypoint-initdb.d:ro'
             - '../databases/db-0:/dbdata:rw'
     peer-node-0:
-        user: '1000:1000'
         container_name: peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
@@ -32,15 +31,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - peer-node-0
         hostname: peer-node-0
     peer-node-1:
-        user: '1000:1000'
         container_name: peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
@@ -57,15 +53,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - peer-node-1
         hostname: peer-node-1
     api-node-0:
-        user: '1000:1000'
         container_name: api-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0"
@@ -83,15 +76,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - api-node-0
         hostname: api-node-0
     api-node-broker-0:
-        user: '1000:1000'
         container_name: api-node-broker-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         working_dir: /symbol-workdir
@@ -112,8 +102,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
@@ -133,8 +121,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 ipv4_address: 172.20.0.25

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -17,7 +17,9 @@ services:
     peer-node-0:
         container_name: peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
+        command: >-
+            bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0
+            DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
@@ -39,7 +41,9 @@ services:
     peer-node-1:
         container_name: peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
+        command: >-
+            bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1
+            DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
@@ -61,7 +65,7 @@ services:
     api-node-0:
         container_name: api-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0"
+        command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0 DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'

--- a/test/composes/expected-docker-compose-bootstrap-full.yml
+++ b/test/composes/expected-docker-compose-bootstrap-full.yml
@@ -22,7 +22,9 @@ services:
     peer-node-0:
         container_name: peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
+        command: >-
+            bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0
+            DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
@@ -44,7 +46,9 @@ services:
     peer-node-1:
         container_name: peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
+        command: >-
+            bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1
+            DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'
@@ -66,7 +70,7 @@ services:
     api-node-0:
         container_name: api-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
-        command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0"
+        command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0 DEBUG"
         stop_signal: SIGINT
         working_dir: /symbol-workdir
         restart: 'on-failure:2'

--- a/test/composes/expected-docker-compose-bootstrap-full.yml
+++ b/test/composes/expected-docker-compose-bootstrap-full.yml
@@ -19,10 +19,7 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
     peer-node-0:
-        user: '1000:1000'
         container_name: peer-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-0 && /bin/bash /symbol-commands/startServer.sh peer-node-0"
@@ -39,15 +36,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - peer-node-0
         hostname: peer-node-0
     peer-node-1:
-        user: '1000:1000'
         container_name: peer-node-1
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/runServerRecover.sh peer-node-1 && /bin/bash /symbol-commands/startServer.sh peer-node-1"
@@ -64,15 +58,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - peer-node-1
         hostname: peer-node-1
     api-node-0:
-        user: '1000:1000'
         container_name: api-node-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         command: bash -c "/bin/bash /symbol-commands/wait.sh ./data/broker.started && /bin/bash /symbol-commands/startServer.sh api-node-0"
@@ -90,15 +81,12 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 aliases:
                     - api-node-0
         hostname: api-node-0
     api-node-broker-0:
-        user: '1000:1000'
         container_name: api-node-broker-0
         image: 'symbolplatform/symbol-server:gcc-0.10.0.6'
         working_dir: /symbol-workdir
@@ -119,8 +107,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
@@ -140,8 +126,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
         networks:
             default:
                 ipv4_address: 172.20.0.25
@@ -160,8 +144,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
     explorer-0:
         container_name: explorer-0
         image: 'symbolplatform/symbol-explorer:0.6.3-alpha'
@@ -179,8 +161,6 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
     faucet-0:
         container_name: faucet-0
         image: 'symbolplatform/symbol-faucet:0.4.0'
@@ -208,11 +188,8 @@ services:
         cap_add:
             - ALL
         privileged: true
-        ulimits:
-            core: -1
 networks:
     default:
         ipam:
             config:
-                -
-                    subnet: 172.20.0.0/24
+                - subnet: 172.20.0.0/24

--- a/test/composes/expected-docker-compose-bootstrap-full.yml
+++ b/test/composes/expected-docker-compose-bootstrap-full.yml
@@ -19,6 +19,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
     peer-node-0:
         user: '1000:1000'
         container_name: peer-node-0
@@ -37,6 +39,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -60,6 +64,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -84,6 +90,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 aliases:
@@ -96,7 +104,7 @@ services:
         working_dir: /symbol-workdir
         command: >-
             bash -c "/bin/bash /symbol-commands/runServerRecover.sh api-node-broker-0 && /bin/bash /symbol-commands/startBroker.sh
-            api-node-broker-0"
+            api-node-broker-0 DEBUG"
         ports:
             - '8002:7902'
         stop_signal: SIGINT
@@ -111,6 +119,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
@@ -130,6 +140,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
         networks:
             default:
                 ipv4_address: 172.20.0.25
@@ -148,6 +160,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
     explorer-0:
         container_name: explorer-0
         image: 'symbolplatform/symbol-explorer:0.6.3-alpha'
@@ -165,6 +179,8 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
     faucet-0:
         container_name: faucet-0
         image: 'symbolplatform/symbol-faucet:0.4.0'
@@ -192,8 +208,11 @@ services:
         cap_add:
             - ALL
         privileged: true
+        ulimits:
+            core: -1
 networks:
     default:
         ipam:
             config:
-                - subnet: 172.20.0.0/24
+                -
+                    subnet: 172.20.0.0/24

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -470,5 +470,4 @@ networks:
     default:
         ipam:
             config:
-                -
-                    subnet: 172.20.0.0/24
+                - subnet: 172.20.0.0/24

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -470,4 +470,5 @@ networks:
     default:
         ipam:
             config:
-                - subnet: 172.20.0.0/24
+                -
+                    subnet: 172.20.0.0/24

--- a/test/custom_bootstrap.yml
+++ b/test/custom_bootstrap.yml
@@ -1,0 +1,1 @@
+dockerComposeDebugMode: true

--- a/test/custom_bootstrap.yml
+++ b/test/custom_bootstrap.yml
@@ -1,1 +1,8 @@
-dockerComposeDebugMode: true
+#dockerComposeDebugMode: true
+#gateways:
+#  - repeat: 0
+#nodes:
+#  - repeat: 1
+#  - repeat: 0
+#databases:
+#  - repeat: 0


### PR DESCRIPTION
I've added core dumps to the server docker scripts. 

When the user runs with a `dockerComposeDebugMode: true` custom preset flag, the nodes will set the core dumps to be saved in the node's ./logs target folder. The only caveat is that the node will run as root as the server docker image doesn't have the `sudo` command installed. Note, the user can bootstrap without sudo, just that the generated service will run as root (by excluding the user: from node services in the compose file). 

Fixes https://github.com/nemtech/symbol-bootstrap/issues/71