### PR TITLE
Local OpenSSL certificate geneartion

### DIFF
--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -53,6 +53,10 @@ export type Password = string | false | undefined;
 export class KnownError extends Error {
     public readonly known = true;
 }
+export interface ExecOutput {
+    stdout: string;
+    stderr: string;
+}
 
 /**
  * The operation to migrate the data.
@@ -269,7 +273,7 @@ export class BootstrapUtils {
         workdir?: string;
         cmds: string[];
         binds: string[];
-    }): Promise<{ stdout: string; stderr: string }> {
+    }): Promise<ExecOutput> {
         const volumes = binds.map((b) => `-v ${b}`).join(' ');
         const userParam = userId ? `-u ${userId}` : '';
         const workdirParam = workdir ? `--workdir=${workdir}` : '';
@@ -471,9 +475,9 @@ export class BootstrapUtils {
         return (await this.exec(runCommand)).stdout;
     }
 
-    public static async exec(runCommand: string): Promise<{ stdout: string; stderr: string }> {
+    public static async exec(runCommand: string, extraParams: any = undefined): Promise<ExecOutput> {
         logger.debug(`Exec command: ${runCommand}`);
-        const { stdout, stderr } = await exec(runCommand);
+        const { stdout, stderr } = await exec(runCommand, extraParams);
         return { stdout, stderr };
     }
 

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -20,7 +20,7 @@ import { LogType } from '../logger';
 import Logger from '../logger/Logger';
 import LoggerFactory from '../logger/LoggerFactory';
 import { CertificatePair } from '../model';
-import { BootstrapUtils } from './BootstrapUtils';
+import { BootstrapUtils, ExecOutput } from './BootstrapUtils';
 import { CommandUtils } from './CommandUtils';
 import { KeyName } from './ConfigService';
 
@@ -87,7 +87,6 @@ export class CertificateService {
         providedCertificates: NodeCertificates,
         customCertFolder?: string,
     ): Promise<void> {
-        const copyFrom = `${this.root}/config/cert`;
         const certFolder = customCertFolder || BootstrapUtils.getTargetNodesFolder(this.params.target, false, name, 'cert');
 
         const metadataFile = join(certFolder, 'metadata.yml');
@@ -96,12 +95,34 @@ export class CertificateService {
             logger.info(`Certificates for node ${name} have been previously generated. Reusing...`);
             return;
         }
+        await this.exec(networkType, symbolServerToolsImage, name, providedCertificates, certFolder);
+        logger.info(`Certificate for node ${name} created`);
+        const metadata: CertificateMetadata = {
+            version: CertificateService.METADATA_VERSION,
+            transportPublicKey: providedCertificates.transport.publicKey,
+            mainPublicKey: providedCertificates.main.publicKey,
+        };
+        await BootstrapUtils.writeYaml(metadataFile, metadata, undefined);
+    }
+
+    private async exec(
+        networkType: NetworkType,
+        symbolServerToolsImage: string,
+        name: string,
+        providedCertificates: NodeCertificates,
+        certFolder: string,
+    ): Promise<ExecOutput> {
+        const copyFrom = `${this.root}/config/cert`;
         await BootstrapUtils.deleteFolder(certFolder);
         await BootstrapUtils.mkdir(certFolder);
         const newCertsFolder = join(certFolder, 'new_certs');
         await BootstrapUtils.mkdir(newCertsFolder);
         const generatedContext = { name };
         await BootstrapUtils.generateConfiguration(generatedContext, copyFrom, certFolder, []);
+        // TODO. Migrate this process to forge, sshpk or any node native implementation.
+        const command = this.createCertCommands();
+        await BootstrapUtils.writeTextFile(join(certFolder, 'createNodeCertificates.sh'), command);
+        const cmd = ['bash', 'createNodeCertificates.sh'];
 
         const mainAccountPrivateKey = await CommandUtils.resolvePrivateKey(networkType, providedCertificates.main, KeyName.Main, name);
         const transportPrivateKey = await CommandUtils.resolvePrivateKey(
@@ -112,20 +133,35 @@ export class CertificateService {
         );
         BootstrapUtils.createDerFile(mainAccountPrivateKey, join(certFolder, 'ca.der'));
         BootstrapUtils.createDerFile(transportPrivateKey, join(certFolder, 'node.der'));
-
-        // TODO. Migrate this process to forge, sshpk or any node native implementation.
-        const command = this.createCertCommands('/data');
-        await BootstrapUtils.writeTextFile(join(certFolder, 'createNodeCertificates.sh'), command);
-        const cmd = ['bash', 'createNodeCertificates.sh'];
+        try {
+            logger.info('Creating certificate using exec and local openssl');
+            const execOutput = await BootstrapUtils.exec(cmd.join(' '), {
+                cwd: certFolder,
+            });
+            await this.validateOutput(execOutput, providedCertificates, mainAccountPrivateKey, transportPrivateKey);
+            return execOutput;
+        } catch (e) {
+            logger.warn('Certificate could not be created using local openssl. Falling back to docker run...');
+        }
         const binds = [`${resolve(certFolder)}:/data:rw`];
         const userId = await BootstrapUtils.resolveDockerUserFromParam(this.params.user);
-        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec({
+        const execOutput = await BootstrapUtils.runImageUsingExec({
             image: symbolServerToolsImage,
             userId: userId,
             workdir: '/data',
             cmds: cmd,
             binds: binds,
         });
+        await this.validateOutput(execOutput, providedCertificates, mainAccountPrivateKey, transportPrivateKey);
+        return execOutput;
+    }
+
+    private async validateOutput(
+        { stdout, stderr }: ExecOutput,
+        providedCertificates: NodeCertificates,
+        mainAccountPrivateKey: string,
+        transportPrivateKey: string,
+    ) {
         if (stdout.indexOf('Certificate Created') < 0) {
             logger.info(BootstrapUtils.secureString(stdout));
             logger.error(BootstrapUtils.secureString(stderr));
@@ -136,21 +172,12 @@ export class CertificateService {
         if (certificates.length != 2) {
             throw new Error('Certificate creation failed. 2 certificates should have been created but got: ' + certificates.length);
         }
-        logger.info(`Certificate for node ${name} created`);
         const caCertificate = certificates[0];
         const nodeCertificate = certificates[1];
-
         BootstrapUtils.validateIsTrue(caCertificate.privateKey === mainAccountPrivateKey, 'Invalid ca private key');
         BootstrapUtils.validateIsTrue(caCertificate.publicKey === providedCertificates.main.publicKey, 'Invalid ca public key');
         BootstrapUtils.validateIsTrue(nodeCertificate.privateKey === transportPrivateKey, 'Invalid Node private key');
         BootstrapUtils.validateIsTrue(nodeCertificate.publicKey === providedCertificates.transport.publicKey, 'Invalid Node public key');
-
-        const metadata: CertificateMetadata = {
-            version: CertificateService.METADATA_VERSION,
-            transportPublicKey: providedCertificates.transport.publicKey,
-            mainPublicKey: providedCertificates.main.publicKey,
-        };
-        await BootstrapUtils.writeYaml(metadataFile, metadata, undefined);
     }
 
     private async shouldGenerateCertificate(metadataFile: string, providedCertificates: NodeCertificates): Promise<boolean> {
@@ -166,9 +193,8 @@ export class CertificateService {
         }
     }
 
-    private createCertCommands(target: string): string {
+    private createCertCommands(): string {
         return `set -e
-cd ${target}
 chmod 700 new_certs
 touch index.txt.attr
 touch index.txt


### PR DESCRIPTION
An offline alternative to https://github.com/nemtech/symbol-bootstrap/issues/1. 
Bootstrap will try to use the local already installed openssl to do the certificate, if not, it will fallback to openssl installed in the server image. 

Related to https://github.com/nemtech/symbol-bootstrap/pull/173 


