### PR TITLE
Fixed `failed to load: /docker-entrypoint-initdb.d/mongoDbPrepare.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 | ---------------- | ------- | ------------------------------------------------------------------ |
 | Symbol Bootstrap | v1.0.5  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
 
+-   Fixed `failed to load: /docker-entrypoint-initdb.d/mongoDbPrepare.js` when running with root user.
 
 ## [1.0.4] - Apr-13-2021
 

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -392,6 +392,21 @@ export class BootstrapUtils {
         );
     }
 
+    public static async chmodRecursive(path: string, mode: string | number): Promise<void> {
+        // Loop through all the files in the config folder
+        const stat = await fsPromises.stat(path);
+        if (stat.isFile()) {
+            await fsPromises.chmod(path, mode);
+        } else if (stat.isDirectory()) {
+            const files = await fsPromises.readdir(path);
+            await Promise.all(
+                files.map(async (file: string) => {
+                    await this.chmodRecursive(join(path, file), mode);
+                }),
+            );
+        }
+    }
+
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     public static runTemplate(template: string, templateContext: any): string {
         const compiledTemplate = Handlebars.compile(template);

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -86,6 +86,8 @@ export class ComposeService {
         await BootstrapUtils.mkdir(targetDocker);
         await BootstrapUtils.generateConfiguration(presetData, join(this.root, 'config', 'docker'), targetDocker);
 
+        await BootstrapUtils.chmodRecursive(join(targetDocker, 'mongo'), 0o666);
+
         const user: string | undefined = await BootstrapUtils.resolveDockerUserFromParam(this.params.user);
 
         const vol = (hostFolder: string, imageFolder: string, readOnly: boolean): string => {


### PR DESCRIPTION
When running with root user.

I'm not a super fan of changing the permissions to 0x666 but the files are public files, the collection indexes js scripts. I think it's fine

Fixes https://github.com/nemtech/symbol-bootstrap/issues/197
It most likely fixes https://github.com/nemtech/symbol-bootstrap/issues/233 but I haven't tried the docker-compose over docker setup