### PR TITLE
Upgraded rest to 2.3.6-alpha

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+/test/reports/**/*.json

--- a/presets/bootstrap/network.yml
+++ b/presets/bootstrap/network.yml
@@ -11,6 +11,7 @@ harvestingName: 'harvest'
 explorerUrl: http://localhost:90/
 faucetUrl: http://localhost:100/
 beneficiaryAddress: ''
+restExtensions: 'accountLink, aggregate, lockHash, lockSecret, mosaic, metadata, multisig, namespace, receipts, restrictions, transfer'
 nemesis:
     mosaics:
         - name: '{{currencyName}}'

--- a/presets/mainnet/network.yml
+++ b/presets/mainnet/network.yml
@@ -48,6 +48,7 @@ maxChildNamespaces: 100
 nonVotingUnfinalizedBlocksDuration: 10m
 votingUnfinalizedBlocksDuration: 0m
 timeSynchronizationMinImportance: 10000000000
+restExtensions: 'accountLink, aggregate, lockHash, lockSecret, mosaic, metadata, multisig, namespace, receipts, restrictions, transfer, cmc'
 knownRestGateways:
     - 'http://ngl-dual-001.symbolblockchain.io:3000'
     - 'http://ngl-dual-002.symbolblockchain.io:3000'

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -65,7 +65,7 @@ maxNamespaceDepth: 3
 batchVerificationRandomSource:
 symbolServerToolsImage: symbolplatform/symbol-server:tools-gcc-1.0.0.0
 symbolServerImage: symbolplatform/symbol-server:gcc-1.0.0.0
-symbolRestImage: symbolplatform/symbol-rest:2.3.5
+symbolRestImage: symbolplatform/symbol-rest:2.3.6-alpha
 symbolExplorerImage: symbolplatform/symbol-explorer:0.6.3-alpha
 symbolWalletImage: symbolplatform/symbol-desktop-wallet:1.0.1
 symbolFaucetImage: symbolplatform/symbol-faucet:0.5.0-alpha
@@ -211,7 +211,6 @@ maxConnectionAttempts: 15
 baseRetryDelay: 750
 connectionPoolSize: 10
 maxSubscriptions: 300
-restExtensions: 'accountLink, aggregate, lockHash, lockSecret, mosaic, metadata, multisig, namespace, receipts, restrictions, transfer, cmc'
 
 #voting
 votingKeyStartEpoch: 1

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -50,6 +50,7 @@ votingUnfinalizedBlocksDuration: 0m
 timeSynchronizationMinImportance: 10000000000
 faucetUrl: 'http://faucet.testnet.symboldev.network'
 explorerUrl: 'http://explorer.testnet.symboldev.network'
+restExtensions: 'accountLink, aggregate, lockHash, lockSecret, mosaic, metadata, multisig, namespace, receipts, restrictions, transfer, cmc'
 knownRestGateways:
     - 'http://ngl-dual-501.testnet.symboldev.network:3000'
     - 'http://ngl-dual-601.testnet.symboldev.network:3000'

--- a/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom-compose.yml
@@ -105,7 +105,7 @@ services:
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-docker-compose-bootstrap-custom.yml
+++ b/test/composes/expected-docker-compose-bootstrap-custom.yml
@@ -103,7 +103,7 @@ services:
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-docker-compose-bootstrap-full.yml
+++ b/test/composes/expected-docker-compose-bootstrap-full.yml
@@ -108,7 +108,7 @@ services:
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-docker-compose-bootstrap-repeat.yml
+++ b/test/composes/expected-docker-compose-bootstrap-repeat.yml
@@ -249,7 +249,7 @@ services:
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -266,7 +266,7 @@ services:
     rest-gateway-1:
         container_name: rest-gateway-1
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -283,7 +283,7 @@ services:
     rest-gateway-2:
         container_name: rest-gateway-2
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir
@@ -300,7 +300,7 @@ services:
     rest-gateway-3:
         container_name: rest-gateway-3
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-docker-compose-bootstrap.yml
+++ b/test/composes/expected-docker-compose-bootstrap.yml
@@ -87,7 +87,7 @@ services:
     rest-gateway-0:
         container_name: rest-gateway-0
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-mainnet-api-compose.yml
+++ b/test/composes/expected-mainnet-api-compose.yml
@@ -44,7 +44,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-mainnet-dual-compose.yml
+++ b/test/composes/expected-mainnet-dual-compose.yml
@@ -44,7 +44,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-api-compose.yml
+++ b/test/composes/expected-testnet-api-compose.yml
@@ -44,7 +44,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-dual-compose.yml
+++ b/test/composes/expected-testnet-dual-compose.yml
@@ -44,7 +44,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-supernode-compose.yml
+++ b/test/composes/expected-testnet-supernode-compose.yml
@@ -61,7 +61,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/composes/expected-testnet-voting-compose.yml
+++ b/test/composes/expected-testnet-voting-compose.yml
@@ -44,7 +44,7 @@ services:
     rest-gateway:
         container_name: rest-gateway
         user: '1000:1000'
-        image: 'symbolplatform/symbol-rest:2.3.5'
+        image: 'symbolplatform/symbol-rest:2.3.6-alpha'
         command: npm start --prefix /app/catapult-rest/rest /symbol-workdir/rest.json
         stop_signal: SIGINT
         working_dir: /symbol-workdir

--- a/test/reports/bootstrap-voting/rest-gateway-0-rest.json
+++ b/test/reports/bootstrap-voting/rest-gateway-0-rest.json
@@ -26,8 +26,7 @@
     "namespace",
     "receipts",
     "restrictions",
-    "transfer",
-    "cmc"
+    "transfer"
   ],
   "db": {
     "url": "mongodb://db-0:27017/",


### PR DESCRIPTION
Upgraded rest to 2.3.6-alpha
cmc rest module disabled on private networks
Fixes https://github.com/nemtech/symbol-bootstrap/issues/253
