### PR TITLE
fix: --customPreset in `link` and `enrollRewardProgram` commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 | Symbol Bootstrap | v1.0.6  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
 
 -   Added `MonitorOnly` reward program.
+-   The `link` and `enrollRewardProgram` commands allow `--customPreset` to avoid password prompt when main private key is not stored in the target folder. 
 
 ## [1.0.5] - May-3-2021
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,7 +18,6 @@ OPTIONS
                                             resolved from the target/preset.yml file.
 
   -c, --customPreset=customPreset           External preset file. Values in this file will override the provided presets
-                                            (optional)
 
   -h, --help                                It shows the help of this command.
 

--- a/docs/enrollRewardProgram.md
+++ b/docs/enrollRewardProgram.md
@@ -16,25 +16,32 @@ USAGE
   $ symbol-bootstrap enrollRewardProgram
 
 OPTIONS
-  -h, --help              It shows the help of this command.
-  -t, --target=target     [default: target] The target folder where the symbol-bootstrap network is generated
-  -u, --url=url           [default: http://localhost:3000] the network url
+  -c, --customPreset=customPreset  This command uses the encrypted addresses.yml to resolve the main private key. If the
+                                   main private is only stored in the custom preset, you can provide it using this
+                                   param. Otherwise, the command may ask for it when required.
 
-  --maxFee=maxFee         the max fee used when announcing (absolute). The node min multiplier will be used if it is not
-                          provided.
+  -h, --help                       It shows the help of this command.
 
-  --noPassword            When provided, Bootstrap will not use a password, so private keys will be stored in plain
-                          text. Use with caution.
+  -t, --target=target              [default: target] The target folder where the symbol-bootstrap network is generated
 
-  --password=password     A password used to encrypt and decrypt private keys in preset files like addresses.yml and
-                          preset.yml. Bootstrap prompts for a password by default, can be provided in the command line
-                          (--password=XXXX) or disabled in the command line (--noPassword).
+  -u, --url=url                    [default: http://localhost:3000] the network url
 
-  --ready                 If --ready is provided, the command will not ask for confirmation when announcing
-                          transactions.
+  --maxFee=maxFee                  the max fee used when announcing (absolute). The node min multiplier will be used if
+                                   it is not provided.
 
-  --useKnownRestGateways  Use the best NEM node available when announcing. Otherwise the command will use the node
-                          provided by the --url parameter.
+  --noPassword                     When provided, Bootstrap will not use a password, so private keys will be stored in
+                                   plain text. Use with caution.
+
+  --password=password              A password used to encrypt and decrypt private keys in preset files like
+                                   addresses.yml and preset.yml. Bootstrap prompts for a password by default, can be
+                                   provided in the command line (--password=XXXX) or disabled in the command line
+                                   (--noPassword).
+
+  --ready                          If --ready is provided, the command will not ask for confirmation when announcing
+                                   transactions.
+
+  --useKnownRestGateways           Use the best NEM node available when announcing. Otherwise the command will use the
+                                   node provided by the --url parameter.
 
 DESCRIPTION
   Currently, the only program that can be enrolled post-launch is 'SuperNode'.

--- a/docs/link.md
+++ b/docs/link.md
@@ -14,27 +14,35 @@ USAGE
   $ symbol-bootstrap link
 
 OPTIONS
-  -h, --help              It shows the help of this command.
-  -t, --target=target     [default: target] The target folder where the symbol-bootstrap network is generated
-  -u, --url=url           [default: http://localhost:3000] the network url
+  -c, --customPreset=customPreset  This command uses the encrypted addresses.yml to resolve the main private key. If the
+                                   main private is only stored in the custom preset, you can provide it using this
+                                   param. Otherwise, the command may ask for it when required.
 
-  --maxFee=maxFee         the max fee used when announcing (absolute). The node min multiplier will be used if it is not
-                          provided.
+  -h, --help                       It shows the help of this command.
 
-  --noPassword            When provided, Bootstrap will not use a password, so private keys will be stored in plain
-                          text. Use with caution.
+  -t, --target=target              [default: target] The target folder where the symbol-bootstrap network is generated
 
-  --password=password     A password used to encrypt and decrypt private keys in preset files like addresses.yml and
-                          preset.yml. Bootstrap prompts for a password by default, can be provided in the command line
-                          (--password=XXXX) or disabled in the command line (--noPassword).
+  -u, --url=url                    [default: http://localhost:3000] the network url
 
-  --ready                 If --ready is provided, the command will not ask for confirmation when announcing
-                          transactions.
+  --maxFee=maxFee                  the max fee used when announcing (absolute). The node min multiplier will be used if
+                                   it is not provided.
 
-  --unlink                Perform "Unlink" transactions unlinking the voting and VRF keys from the node signer account
+  --noPassword                     When provided, Bootstrap will not use a password, so private keys will be stored in
+                                   plain text. Use with caution.
 
-  --useKnownRestGateways  Use the best NEM node available when announcing. Otherwise the command will use the node
-                          provided by the --url parameter.
+  --password=password              A password used to encrypt and decrypt private keys in preset files like
+                                   addresses.yml and preset.yml. Bootstrap prompts for a password by default, can be
+                                   provided in the command line (--password=XXXX) or disabled in the command line
+                                   (--noPassword).
+
+  --ready                          If --ready is provided, the command will not ask for confirmation when announcing
+                                   transactions.
+
+  --unlink                         Perform "Unlink" transactions unlinking the voting and VRF keys from the node signer
+                                   account
+
+  --useKnownRestGateways           Use the best NEM node available when announcing. Otherwise the command will use the
+                                   node provided by the --url parameter.
 
 EXAMPLES
   $ symbol-bootstrap link

--- a/docs/start.md
+++ b/docs/start.md
@@ -21,7 +21,7 @@ OPTIONS
       If provided, docker-compose will run with -b (--build)
 
   -c, --customPreset=customPreset
-      External preset file. Values in this file will override the provided presets (optional)
+      External preset file. Values in this file will override the provided presets
 
   -d, --detached
       If provided, docker-compose will run with -d (--detached) and this command will wait unit server is running before 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -27,27 +27,30 @@ export default class Config extends Command {
         `$ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap config -p testnet -a dual`,
     ];
 
-    static flags = {
+    static resolveFlags = (required: boolean) => ({
         help: CommandUtils.helpFlag,
         target: CommandUtils.targetFlag,
         password: CommandUtils.passwordFlag,
         noPassword: CommandUtils.noPasswordFlag,
         preset: flags.enum({
             char: 'p',
-            description:
-                'The network preset, can be provided via custom preset or cli parameter. If not provided, the value is resolved from the target/preset.yml file.',
+            description: `The network preset, can be provided via custom preset or cli parameter. ${
+                required ? '' : 'If not provided, the value is resolved from the target/preset.yml file.'
+            }`,
             options: Object.keys(Preset).map((v) => v as Preset),
+            required: required,
         }),
         assembly: flags.string({
             char: 'a',
-            description:
-                'The assembly, example "dual" for testnet. If not provided, the value is resolved from the target/preset.yml file.',
+            description: `The assembly, example "dual" for testnet. ${
+                required ? '' : 'If not provided, the value is resolved from the target/preset.yml file.'
+            }`,
+            required: required,
         }),
-
         customPreset: flags.string({
             char: 'c',
-            description: 'External preset file. Values in this file will override the provided presets (optional)',
-            required: false,
+            description: `External preset file. Values in this file will override the provided presets`,
+            required: required,
         }),
         reset: flags.boolean({
             char: 'r',
@@ -76,7 +79,9 @@ export default class Config extends Command {
             description: `User used to run docker images when creating configuration files like certificates or nemesis block. "${BootstrapUtils.CURRENT_USER}" means the current user.`,
             default: BootstrapUtils.CURRENT_USER,
         }),
-    };
+    });
+
+    static flags = Config.resolveFlags(false);
 
     public async run(): Promise<void> {
         const { flags } = this.parse(Config);

--- a/src/service/AnnounceService.ts
+++ b/src/service/AnnounceService.ts
@@ -90,6 +90,11 @@ export class AnnounceService {
         maxFee: flags.integer({
             description: 'the max fee used when announcing (absolute). The node min multiplier will be used if it is not provided.',
         }),
+        customPreset: flags.string({
+            char: 'c',
+            description: `This command uses the encrypted addresses.yml to resolve the main private key. If the main private is only stored in the custom preset, you can provide it using this param. Otherwise, the command may ask for it when required.`,
+            required: false,
+        }),
     };
     public async announce(
         providedUrl: string,
@@ -209,6 +214,27 @@ export class AnnounceService {
                 return response;
             };
 
+            const resolveMainAccount = async (): Promise<Account> => {
+                const presetMainPrivateKey = (presetData.nodes || [])[index]?.mainPrivateKey;
+                if (presetMainPrivateKey) {
+                    const account = Account.createFromPrivateKey(presetMainPrivateKey, networkType);
+                    if (account.address.equals(mainAccount.address)) {
+                        return account;
+                    }
+                }
+
+                return Account.createFromPrivateKey(
+                    await CommandUtils.resolvePrivateKey(
+                        networkType,
+                        nodeAccount.main,
+                        KeyName.Main,
+                        nodeAccount.name,
+                        'signing a transaction',
+                    ),
+                    networkType,
+                );
+            };
+
             if (multisigAccountInfo) {
                 logger.info(
                     `The node's main account is a multig account with Address: ${
@@ -318,16 +344,7 @@ export class AnnounceService {
                     }
                 }
             } else {
-                const signerAccount = Account.createFromPrivateKey(
-                    await CommandUtils.resolvePrivateKey(
-                        networkType,
-                        nodeAccount.main,
-                        KeyName.Main,
-                        nodeAccount.name,
-                        'signing a transaction',
-                    ),
-                    networkType,
-                );
+                const signerAccount = await resolveMainAccount();
                 if (transactions.length == 1) {
                     let transaction = transactions[0];
                     if (!providedMaxFee) {

--- a/src/service/CommandUtils.ts
+++ b/src/service/CommandUtils.ts
@@ -26,7 +26,7 @@ import { KeyName } from './ConfigService';
 const logger: Logger = LoggerFactory.getLogger(LogType.System);
 
 export class CommandUtils {
-    public static passwordPromptDefaultMessage = `Enter password to use to encrypt and decrypt custom presets, addresses.yml, and preset.yml files. When providing a password, private keys will be encrypted. Keep this password in a secure place!`;
+    public static passwordPromptDefaultMessage = `Enter the password used to encrypt and decrypt custom presets, addresses.yml, and preset.yml files. When providing a password, private keys will be encrypted. Keep this password in a secure place!`;
     public static helpFlag = flags.help({ char: 'h', description: 'It shows the help of this command.' });
 
     public static targetFlag = flags.string({

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -39,7 +39,7 @@ import { CryptoUtils } from './CryptoUtils';
 const logger: Logger = LoggerFactory.getLogger(LogType.System);
 
 export class ConfigLoader {
-    private static presetInfoLogged = false;
+    public static presetInfoLogged = false;
 
     public async generateRandomConfiguration(oldAddresses: Addresses | undefined, presetData: ConfigPreset): Promise<Addresses> {
         const networkType = presetData.networkType;
@@ -340,7 +340,8 @@ export class ConfigLoader {
     private static getArray(size: number): number[] {
         return [...Array(size).keys()];
     }
-    private loadCustomPreset(customPreset: string | undefined, password: string | undefined): CustomPreset {
+
+    public loadCustomPreset(customPreset: string | undefined, password: Password): CustomPreset {
         if (!customPreset) {
             return {};
         }
@@ -365,8 +366,16 @@ export class ConfigLoader {
         return BootstrapUtils.loadYaml(fileLocation, false);
     }
 
+    public mergePresets(object: ConfigPreset, ...otherArgs: (CustomPreset | undefined)[]): any {
+        const presets: (CustomPreset | undefined)[] = [object, ...otherArgs];
+        const inflation: Record<string, number> = presets.reverse().find((p) => p?.inflation)?.inflation || {};
+        const presetData = _.merge(object, ...otherArgs);
+        presetData.inflation = inflation;
+        return presetData;
+    }
+
     public createPresetData(params: {
-        password: string | undefined;
+        password: Password;
         root: string;
         preset?: Preset;
         assembly?: string;
@@ -392,21 +401,14 @@ export class ConfigLoader {
         const sharedPreset = BootstrapUtils.loadYaml(join(root, 'presets', 'shared.yml'), false);
         const networkPreset = BootstrapUtils.loadYaml(`${root}/presets/${preset}/network.yml`, false);
         const assemblyPreset = this.loadAssembly(root, preset, assembly);
-        //Deep merge
-        const inflation: Record<string, number> =
-            customPresetObject?.inflation ||
-            customPresetFileObject?.inflation ||
-            assemblyPreset?.inflation ||
-            networkPreset?.inflation ||
-            sharedPreset?.inflation ||
-            [];
-        const presetData = _.merge(sharedPreset, networkPreset, assemblyPreset, customPresetFileObject, customPresetObject, {
+
+        const presetData = this.mergePresets(sharedPreset, networkPreset, assemblyPreset, customPresetFileObject, customPresetObject, {
             preset,
         });
+
         if (presetData.assemblies && !assembly) {
             throw new Error(`Preset ${preset} requires assembly (-a, --assembly option). Possible values are: ${presetData.assemblies}`);
         }
-        presetData.inflation = inflation;
         if (!ConfigLoader.presetInfoLogged) {
             logger.info(`Generating config from preset '${preset}'`);
             if (assembly) {

--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -34,7 +34,7 @@ import Logger from '../logger/Logger';
 import LoggerFactory from '../logger/LoggerFactory';
 import { Addresses, ConfigPreset, CustomPreset, NodeAccount, NodePreset, NodeType } from '../model';
 import { AgentCertificateService } from './AgentCertificateService';
-import { BootstrapUtils, KnownError } from './BootstrapUtils';
+import { BootstrapUtils, KnownError, Password } from './BootstrapUtils';
 import { CertificateService } from './CertificateService';
 import { CommandUtils } from './CommandUtils';
 import { ConfigLoader } from './ConfigLoader';
@@ -176,7 +176,7 @@ export class ConfigService {
         }
     }
 
-    private resolveCurrentPresetData(oldPresetData: ConfigPreset | undefined, password: string | undefined) {
+    private resolveCurrentPresetData(oldPresetData: ConfigPreset | undefined, password: Password) {
         return this.configLoader.createPresetData({ ...this.params, root: this.root, password: password, oldPresetData });
     }
 

--- a/src/service/LinkService.ts
+++ b/src/service/LinkService.ts
@@ -45,6 +45,7 @@ export type LinkParams = {
     unlink: boolean;
     useKnownRestGateways: boolean;
     ready?: boolean;
+    customPreset?: string;
 };
 
 const logger: Logger = LoggerFactory.getLogger(LogType.System);
@@ -77,6 +78,7 @@ export class LinkService implements TransactionFactory {
     public async run(passedPresetData?: ConfigPreset | undefined, passedAddresses?: Addresses | undefined): Promise<void> {
         const presetData = passedPresetData ?? this.configLoader.loadExistingPresetData(this.params.target, this.params.password);
         const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
+        const customPreset = this.configLoader.loadCustomPreset(this.params.customPreset, this.params.password);
         logger.info(`${this.params.unlink ? 'Unlinking' : 'Linking'} nodes`);
 
         await new AnnounceService().announce(
@@ -84,7 +86,7 @@ export class LinkService implements TransactionFactory {
             this.params.maxFee,
             this.params.useKnownRestGateways,
             this.params.ready,
-            presetData,
+            this.configLoader.mergePresets(presetData, customPreset),
             addresses,
             this,
         );

--- a/src/service/RewardProgramService.ts
+++ b/src/service/RewardProgramService.ts
@@ -32,6 +32,7 @@ export type RewardProgramParams = {
     maxFee?: number;
     useKnownRestGateways: boolean;
     ready?: boolean;
+    customPreset?: string;
 };
 
 export interface RewardProgramServiceTransactionFactoryParams {
@@ -74,6 +75,7 @@ export class RewardProgramService implements TransactionFactory {
     public async enroll(passedPresetData?: ConfigPreset | undefined, passedAddresses?: Addresses | undefined): Promise<void> {
         const presetData = passedPresetData ?? this.configLoader.loadExistingPresetData(this.params.target, this.params.password);
         const addresses = passedAddresses ?? this.configLoader.loadExistingAddresses(this.params.target, this.params.password);
+        const customPreset = this.configLoader.loadCustomPreset(this.params.customPreset, this.params.password);
         if (!presetData.rewardProgramEnrollmentAddress) {
             logger.warn('This network does not have a reward program controller public key. Nodes cannot be registered.');
             return;
@@ -83,7 +85,7 @@ export class RewardProgramService implements TransactionFactory {
             this.params.maxFee,
             this.params.useKnownRestGateways,
             this.params.ready,
-            presetData,
+            this.configLoader.mergePresets(presetData, customPreset),
             addresses,
             this,
             '1M+',


### PR DESCRIPTION
Code improvement around merging preset objects.

The `link` and `enrollRewardProgram` commands allow `--customPreset` to avoid password prompt when main private key is not stored in the target/addresses.yml file