### PR TITLE
[bootstrap] task: add option to configure node metadata

### DIFF
--- a/config/rest-gateway/rest.json.mustache
+++ b/config/rest-gateway/rest.json.mustache
@@ -79,5 +79,7 @@
     "deploymentTool": "{{{restDeploymentTool}}}",
     "deploymentToolVersion": "{{{restDeploymentToolVersion}}}",
     "lastUpdatedDate": "{{{restDeploymentToolLastUpdatedDate}}}"
-  }
+  },
+
+  "nodeMetadata": {{{toJson restNodeMetadata}}}
 }

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -227,6 +227,8 @@ restProtocol: HTTP
 restSSLPath: '/symbol-workdir'
 restSSLKeyFileName: 'restSSL.key'
 restSSLCertificateFileName: 'restSSL.crt'
+restNodeMetadata:
+  _info: "Node metadata"
 statisticsServicePeerFilter: ''
 statisticsServicePeerLimit: 50
 statisticsServiceRestFilter: suggested

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -318,6 +318,7 @@ export interface GatewayConfigPreset {
     restProtocol: 'HTTPS' | 'HTTP';
     restExtensions: string;
     restUncirculatingAccountPublicKeys: string;
+    restNodeMetadata: Map<string, any>;
     restSSLPath: string;
     restSSLKeyFileName: string;
     restSSLCertificateFileName: string;

--- a/test/reports/bootstrap-voting/rest-gateway-0-rest.json
+++ b/test/reports/bootstrap-voting/rest-gateway-0-rest.json
@@ -92,5 +92,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "abc",
     "lastUpdatedDate": "2021-05-23"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }

--- a/test/reports/custom-network-dual/rest-gateway-rest.json
+++ b/test/reports/custom-network-dual/rest-gateway-rest.json
@@ -92,5 +92,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "abc",
     "lastUpdatedDate": "2021-05-23"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }

--- a/test/reports/mainnet-dual-voting/rest-gateway-rest.json
+++ b/test/reports/mainnet-dual-voting/rest-gateway-rest.json
@@ -97,5 +97,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "abc",
     "lastUpdatedDate": "2021-05-23"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }

--- a/test/reports/mainnet-dual/rest-gateway-rest.json
+++ b/test/reports/mainnet-dual/rest-gateway-rest.json
@@ -97,5 +97,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "abc",
     "lastUpdatedDate": "2021-05-23"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }

--- a/test/reports/testnet-api/rest-gateway-rest.json
+++ b/test/reports/testnet-api/rest-gateway-rest.json
@@ -92,5 +92,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "ABC",
     "lastUpdatedDate": "2021-05-23"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }

--- a/test/reports/testnet-dual-voting/rest-gateway-rest.json
+++ b/test/reports/testnet-dual-voting/rest-gateway-rest.json
@@ -92,5 +92,8 @@
     "deploymentTool": "symbol-bootstrap",
     "deploymentToolVersion": "abc",
     "lastUpdatedDate": "2021-05-22"
+  },
+  "nodeMetadata": {
+    "_info": "Node metadata"
   }
 }


### PR DESCRIPTION
## What's the issue?

Newly added endpoint /node/metadata in REST returns meta-information about the node. Bootstrap doesn't allow users to define custom values for this endpoint.

## What's the solution?

Add the possibility to define node meta-information via custom preset. This can be done by:

```
gateways:
-  restNodeMetadata:
    key11: "value1"
    key21: "value2"
    key31: "value4"
    key51: 1
    key61: 10
```

